### PR TITLE
fixed: monitor of sbd resource

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,7 @@ srpm:	export
 	rpmbuild $(RPM_OPTS) -bs $(PACKAGE).spec
 
 rpm:	export
+	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(PACKAGE).spec
 	rpmbuild $(RPM_OPTS) -ba $(PACKAGE).spec
 
 mock:   srpm

--- a/agent/sbd
+++ b/agent/sbd
@@ -82,7 +82,7 @@ off|reset)
 status)
     sbd_check_device
     sbd_validate_timeout
-    if ! sbd -d $sbd_device list >/dev/null 2>&1 ; then
+    if ! ps aux|grep "sbd: inquisitor"|grep -v grep; then
     	ha_log.sh err "sbd could not list nodes from $sbd_device"
     	exit 1
     fi


### PR DESCRIPTION
As "sbd list" always returns 0, even though sbd daemon is not running.
Pacemaker will think sbd resource is running even sbd daemon is not
running, it might be better to check whether sbd daemon is running.
