### PR TITLE
Set SBD_STARTMODE to "always" by default

### DIFF
--- a/src/sbd.sysconfig
+++ b/src/sbd.sysconfig
@@ -21,7 +21,7 @@ SBD_PACEMAKER=yes
 # allow sbd to start if it was not previously fenced. See the -S option
 # in the man page.
 #
-SBD_STARTMODE=clean
+SBD_STARTMODE=always
 
 ## Type: yesno
 ## Default: no


### PR DESCRIPTION
According to the documentation and the comment in the sysconfig file,
the default for SBD_STARTMODE should be "always".

The other option here is to update the documentation to document
"clean" as the default. If you'd prefer that, I can flip this patch - though 
I think retaining the defaults is the less surprising choice.
