### PR TITLE
Clarify documentation around watchdog option (-W)

### DIFF
--- a/man/sbd.8.pod
+++ b/man/sbd.8.pod
@@ -171,7 +171,7 @@ Dump meta-data header from device.
 
 Example usage:
 
-	sbd -d /dev/sdc2 -d /dev/sdd3 -W -P watch
+	sbd -d /dev/sdc2 -d /dev/sdd3 -P watch
 
 This command will make C<sbd> start in daemon mode. It will constantly monitor
 the message slot of the local node for incoming messages, reachability, and

--- a/src/sbd.sysconfig
+++ b/src/sbd.sysconfig
@@ -36,10 +36,11 @@ SBD_STARTMODE=always
 #
 SBD_DELAY_START=no
 
-## Type: yesno
-## Default: yes
+## Type: string
+## Default: /dev/watchdog
 #
-# Whether to use a watchdog.
+# Watchdog device to use. If set to /dev/null, no watchdog device will
+# be used.
 #
 SBD_WATCHDOG_DEV=/dev/watchdog
 


### PR DESCRIPTION
This patch removes the vestigial SBD_WATCHDOG option completely.
The watchdog is enabled by default and configured to use /dev/watchdog.
By passing /dev/null as the watchdog device, use of the watchdog can
be disabled.

Update the documentation to reflect this change.
