### PR TITLE
fixed:Makefile.am:substitute commit in sbd.spec when running "make rpm"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,16 +29,19 @@ export:
 	    echo `date`: Rebuilt $(TARFILE);					\
 	fi
 
-srpm:	export
+#replace commit id in sbd.spce
+replace:
 	rm -f *.src.rpm
 	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(PACKAGE).spec
+
+srpm:	replace export
 	if [ -e $(BUILD_COUNTER) ]; then							\
 		sed -i 's/global\ buildnum.*/global\ buildnum\ $(COUNT)/' $(PACKAGE).spec;	\
 		echo $(COUNT) > $(BUILD_COUNTER);					\
 	fi
 	rpmbuild $(RPM_OPTS) -bs $(PACKAGE).spec
 
-rpm:	export
+rpm:	replace export
 	rpmbuild $(RPM_OPTS) -ba $(PACKAGE).spec
 
 mock:   srpm

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,18 +30,18 @@ export:
 	fi
 
 #replace commit id in sbd.spce
-replace:
+spec:
 	rm -f *.src.rpm
 	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(PACKAGE).spec
 
-srpm:	replace export
+srpm:	spec export
 	if [ -e $(BUILD_COUNTER) ]; then							\
 		sed -i 's/global\ buildnum.*/global\ buildnum\ $(COUNT)/' $(PACKAGE).spec;	\
 		echo $(COUNT) > $(BUILD_COUNTER);					\
 	fi
 	rpmbuild $(RPM_OPTS) -bs $(PACKAGE).spec
 
-rpm:	replace export
+rpm:	spec export
 	rpmbuild $(RPM_OPTS) -ba $(PACKAGE).spec
 
 mock:   srpm


### PR DESCRIPTION
If user run "make rpm" without running "make srpm",
it will report error that tarball does not exist, that
is because the commit in spec does not change.
