### PR TITLE
build: fix error when compiling with format-security

### DIFF
--- a/src/sbd-common.c
+++ b/src/sbd-common.c
@@ -687,7 +687,7 @@ set_servant_health(enum pcmk_health state, int level, char const *format, ...)
         len = vasprintf (&string, format, ap);
 
         if(len > 0) {
-            cl_log(level, string);
+            cl_log(level, "%s", string);
         }
         
         va_end(ap);


### PR DESCRIPTION
Within set_servant_health cl_log is called with a string variable and no
parameters. This leads to compiler errors when building with --Wformat
--Werror=format-security.

Introduce a dummy format string ("%s") to suppress this error.
