### PR TITLE
Add LSB init

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,7 +203,7 @@ eval infodir="`eval echo ${infodir}`"
 eval mandir="`eval echo ${mandir}`"
 
 dnl The Makefiles and shell scripts we output
-AC_CONFIG_FILES([Makefile src/Makefile agent/Makefile man/Makefile src/sbd.service src/sbd_remote.service])
+AC_CONFIG_FILES([Makefile src/Makefile agent/Makefile man/Makefile src/sbd.service src/sbd_remote.service src/sbd_helper src/sbd_remote_helper])
 
 dnl Now process the entire list of files added by previous 
 dnl  calls to AC_CONFIG_FILES()

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,18 @@ then
 	AC_DEFINE_UNQUOTED(HAVE_PROC_PID, 1, Define to 1 if /proc/{pid} is supported.)
 fi
 
+INITDIR=""
+AC_ARG_WITH(initdir,
+    [  --with-initdir=DIR      directory for init (rc) scripts [${INITDIR}]],
+    [ INITDIR="$withval" ])
+
+CONFIGDIR=""
+AC_ARG_WITH(configdir,
+    [  --with-configdir=DIR
+       Directory for Pacemaker configuration file [${CONFIGDIR}]],
+    [ CONFIGDIR="$withval" ]
+)
+
 dnl **********************************************************************
 dnl Check for various argv[] replacing functions on various OSs
 dnl
@@ -201,6 +213,31 @@ eval includedir="`eval echo ${includedir}`"
 eval oldincludedir="`eval echo ${oldincludedir}`"
 eval infodir="`eval echo ${infodir}`"
 eval mandir="`eval echo ${mandir}`"
+
+dnl Home-grown variables
+eval INITDIR="${INITDIR}"
+AC_MSG_NOTICE(Sanitizing INITDIR: ${INITDIR})
+case $INITDIR in
+  prefix) INITDIR=$prefix;;
+  "")
+    AC_MSG_CHECKING(which init (rc) directory to use)
+      for initdir in /etc/init.d /etc/rc.d/init.d /sbin/init.d  \
+           /usr/local/etc/rc.d /etc/rc.d
+      do
+        if
+          test -d $initdir
+        then
+          INITDIR=$initdir
+          break
+        fi
+      done
+      AC_MSG_RESULT($INITDIR);;
+esac
+AC_SUBST(INITDIR)
+if test x"${CONFIGDIR}" = x""; then
+    CONFIGDIR="${sysconfdir}/sysconfig"
+fi
+AC_SUBST(CONFIGDIR)
 
 dnl The Makefiles and shell scripts we output
 AC_CONFIG_FILES([Makefile src/Makefile agent/Makefile man/Makefile src/sbd.service src/sbd_remote.service src/sbd_helper src/sbd_remote_helper])

--- a/src/sbd_helper.in
+++ b/src/sbd_helper.in
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+# Authors:
+#  Klaus Wenninger <kwenning@redhat.com>
+#
+# License: Revised BSD
+
+# chkconfig: - 99 01
+# description: Shared-storage based fencing daemon
+# processname: sbd
+#
+### BEGIN INIT INFO
+# Provides:		sbd_helper
+# Required-Start:	$local_fs $remote_fs
+# Should-Start:		$syslog iscsi open-iscsi
+# Should-Stop:		$syslog iscsi open-iscsi
+# X-Start-Before: 	corosync
+# X-Stop-After: 	corosync
+# Required-Stop:	$local_fs $remote_fs
+# Default-Start:
+# Default-Stop:
+# Short-Description:	Starts and stops Shared-storage based fencing daemon.
+# Description:		Starts and stops Shared-storage based fencing daemon.
+### END INIT INFO
+
+desc="Shared-storage based fencing daemon"
+prog="sbd"
+pidfile="@localstatedir@/run/${prog}.pid"
+
+# set secure PATH
+PATH="/sbin:/bin:/usr/sbin:/usr/bin:@sbindir@"
+
+checkrc() {
+	if [ $? = 0 ]; then
+		success
+	else
+		failure
+	fi
+}
+
+success()
+{
+	echo -ne "[  OK  ]\r"
+}
+
+failure()
+{
+	echo -ne "[FAILED]\r"
+}
+
+log()
+{
+	logger -t sbd -p daemon.notice "$*"
+}
+
+notify()
+{
+	log "$*"
+	echo -n "   $*"
+}
+
+sbd_status()
+{
+	pid=$(cat "$pidfile" 2>/dev/null)
+	status_rtrn=$?
+	if [ $status_rtrn -eq 0 ]; then
+		kill -0 $pid > /dev/null 2>&1
+		status_rtrn=$?
+	fi
+	if [ $status_rtrn -ne 0 ]; then
+		if [ -f "$pidfile" ]; then
+			status_rtrn=1
+		else
+			status_rtrn=3
+		fi
+		rm -f "$pidfile"
+		echo "$prog is stopped"
+	else
+		echo "$prog (pid $pid) is running..."
+	fi
+	return $status_rtrn
+}
+
+if [ -d @CONFIGDIR@ ]; then
+	[ -f @INITDIR@/functions ] && . @INITDIR@/functions
+set -a
+	[ -f @CONFIGDIR@/sbd ] && . @CONFIGDIR@/sbd
+set +a
+fi
+
+LOCK_DIR="."
+if [ -d "@localstatedir@/lock/subsys" ]; then
+	LOCK_DIR="@localstatedir@/lock/subsys"
+elif [ -d "@localstatedir@/lock" ]; then
+	LOCK_DIR="@localstatedir@/lock"
+fi
+[ -z "$LOCK_FILE" ] && LOCK_FILE="$LOCK_DIR/sbd"
+
+start()
+{
+	notify "Starting $desc"
+
+	if sbd_status > /dev/null 2>&1; then
+		success
+	else
+		$prog $SBD_OPTS -p "$pidfile" watch > /dev/null 2>&1
+
+		# give it a little time to fail after daemonization
+		sleep 2
+
+		if sbd_status > /dev/null 2>&1; then
+			touch "$LOCK_FILE"
+			success
+		else
+			failure
+			rtrn=1
+		fi
+	fi
+	echo
+}
+
+stop()
+{
+	if sbd_status > /dev/null 2>&1; then
+	    notify "Signaling $desc to terminate"
+	    kill -TERM $(cat "$pidfile") > /dev/null 2>&1
+	    checkrc
+	    echo
+
+	    notify "Waiting for sbd to unload"
+	    while sbd_status > /dev/null 2>&1; do
+		sleep 1
+		echo -n "."
+	    done
+	else
+	    echo -n "$desc is already stopped"
+	fi
+
+	rm -f "$LOCK_FILE"
+	rm -f "$pidfile"
+	killall -q -9 sbd
+	success
+	echo
+}
+
+rtrn=0
+
+case "$1" in
+start)
+	start
+;;
+restart|reload|force-reload)
+	stop
+	start
+;;
+condrestart|try-restart)
+	if sbd_status > /dev/null 2>&1; then
+	    stop
+	    start
+	fi
+;;
+status)
+	sbd_status
+	rtrn=$?
+;;
+stop)
+	stop
+;;
+*)
+	echo "usage: $0 {start|stop|restart|reload|force-reload|condrestart|try-restart|status}"
+	rtrn=2
+;;
+esac
+
+exit $rtrn

--- a/src/sbd_remote_helper.in
+++ b/src/sbd_remote_helper.in
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+# Authors:
+#  Klaus Wenninger <kwenning@redhat.com>
+#
+# License: Revised BSD
+
+# chkconfig: - 99 01
+# description: Shared-storage based fencing daemon
+# processname: sbd
+#
+### BEGIN INIT INFO
+# Provides:		sbd_remote_helper
+# Required-Start:	$local_fs $remote_fs
+# Should-Start:		$syslog iscsi open-iscsi
+# Should-Stop:		$syslog iscsi open-iscsi
+# Required-Stop:	$local_fs $remote_fs
+# Default-Start:
+# Default-Stop:
+# Short-Description:	Starts and stops Shared-storage based fencing daemon.
+# Description:		Starts and stops Shared-storage based fencing daemon.
+### END INIT INFO
+
+desc="Shared-storage based fencing daemon"
+prog="sbd"
+pidfile="@localstatedir@/run/${prog}.pid"
+
+# set secure PATH
+PATH="/sbin:/bin:/usr/sbin:/usr/bin:@sbindir@"
+
+checkrc() {
+	if [ $? = 0 ]; then
+		success
+	else
+		failure
+	fi
+}
+
+success()
+{
+	echo -ne "[  OK  ]\r"
+}
+
+failure()
+{
+	echo -ne "[FAILED]\r"
+}
+
+log()
+{
+	logger -t sbd -p daemon.notice "$*"
+}
+
+notify()
+{
+	log "$*"
+	echo -n "   $*"
+}
+
+sbd_status()
+{
+	pid=$(cat "$pidfile" 2>/dev/null)
+	status_rtrn=$?
+	if [ $status_rtrn -eq 0 ]; then
+		kill -0 $pid > /dev/null 2>&1
+		status_rtrn=$?
+	fi
+	if [ $status_rtrn -ne 0 ]; then
+		if [ -f "$pidfile" ]; then
+			status_rtrn=1
+		else
+			status_rtrn=3
+		fi
+		rm -f "$pidfile"
+		echo "$prog is stopped"
+	else
+		echo "$prog (pid $pid) is running..."
+	fi
+	return $status_rtrn
+}
+
+if [ -d @CONFIGDIR@ ]; then
+	[ -f @INITDIR@/functions ] && . @INITDIR@/functions
+set -a
+	[ -f @CONFIGDIR@/sbd ] && . @CONFIGDIR@/sbd
+set +a
+fi
+
+LOCK_DIR="."
+if [ -d "@localstatedir@/lock/subsys" ]; then
+	LOCK_DIR="@localstatedir@/lock/subsys"
+elif [ -d "@localstatedir@/lock" ]; then
+	LOCK_DIR="@localstatedir@/lock"
+fi
+[ -z "$LOCK_FILE" ] && LOCK_FILE="$LOCK_DIR/sbd"
+
+start()
+{
+	notify "Starting $desc"
+
+	if sbd_status > /dev/null 2>&1; then
+		success
+	else
+		$prog $SBD_OPTS -p "$pidfile" watch > /dev/null 2>&1
+
+		# give it a little time to fail after daemonization
+		sleep 2
+
+		if sbd_status > /dev/null 2>&1; then
+			touch "$LOCK_FILE"
+			success
+		else
+			failure
+			rtrn=1
+		fi
+	fi
+	echo
+}
+
+stop()
+{
+	if sbd_status > /dev/null 2>&1; then
+	    notify "Signaling $desc to terminate"
+	    kill -TERM $(cat "$pidfile") > /dev/null 2>&1
+	    checkrc
+	    echo
+
+	    notify "Waiting for sbd to unload"
+	    while sbd_status > /dev/null 2>&1; do
+		sleep 1
+		echo -n "."
+	    done
+	else
+	    echo -n "$desc is already stopped"
+	fi
+
+	rm -f "$LOCK_FILE"
+	rm -f "$pidfile"
+	killall -q -9 sbd
+	success
+	echo
+}
+
+rtrn=0
+
+case "$1" in
+start)
+	start
+;;
+restart|reload|force-reload)
+	stop
+	start
+;;
+condrestart|try-restart)
+	if sbd_status > /dev/null 2>&1; then
+	    stop
+	    start
+	fi
+;;
+status)
+	sbd_status
+	rtrn=$?
+;;
+stop)
+	stop
+;;
+*)
+	echo "usage: $0 {start|stop|restart|reload|force-reload|condrestart|try-restart|status}"
+	rtrn=2
+;;
+esac
+
+exit $rtrn


### PR DESCRIPTION
Added LSB init scripts for sbd to monitor pacemaker remode and full nodes.
systemd gives us the possibility to prevent people from fiddling around with
the sbd unit-files manually. To make people shy away from starting/stopping
sbd using the LSB init scripts they are called sbd_helper and sbd_remote_helper.
