### PR TITLE
Fix reboot req on sysrq not working

### DIFF
--- a/src/sbd-common.c
+++ b/src/sbd-common.c
@@ -696,3 +696,36 @@ set_servant_health(enum pcmk_health state, int level, char const *format, ...)
         free(string);
     }
 }
+
+bool
+sbd_is_disk(struct servants_list_item *servant)
+{
+    if ((servant != NULL) &&
+        (servant->devname != NULL) &&
+        (servant->devname[0] == '/')) {
+        return true;
+    }
+    return false;
+}
+
+bool
+sbd_is_cluster(struct servants_list_item *servant)
+{
+    if ((servant != NULL) &&
+        (servant->devname != NULL) &&
+        (strcmp("cluster", servant->devname) == 0)) {
+        return true;
+    }
+    return false;
+}
+
+bool
+sbd_is_pcmk(struct servants_list_item *servant)
+{
+    if ((servant != NULL) &&
+        (servant->devname != NULL) &&
+        (strcmp("pcmk", servant->devname) == 0)) {
+        return true;
+    }
+    return false;
+}

--- a/src/sbd-md.c
+++ b/src/sbd-md.c
@@ -29,7 +29,6 @@
 #define MBOX_TO_SECTOR(mbox) (2+mbox*2)
 
 extern int disk_count;
-static int servant_inform_parent = 0;
 
 /* These have to match the values in the header of the partition */
 static char		sbd_magic[8] = "SBD_SBD_";
@@ -1025,20 +1024,6 @@ static int servant_check_timeout_inconsistent(struct sector_header_s *hdr)
 	return 0;
 }
 
-/* This is a bit hackish, but the easiest way to rewire all process
- * exits to send the desired signal to the parent. */
-void servant_exit(void)
-{
-	pid_t ppid;
-	union sigval signal_value;
-
-	ppid = getppid();
-	if (servant_inform_parent) {
-		memset(&signal_value, 0, sizeof(signal_value));
-		sigqueue(ppid, SIG_IO_FAIL, signal_value);
-	}
-}
-
 int servant(const char *diskname, int mode, const void* argp)
 {
 	struct sector_mbox_s *s_mbox = NULL;
@@ -1072,24 +1057,21 @@ int servant(const char *diskname, int mode, const void* argp)
 	/* FIXME: check error */
 	sigprocmask(SIG_SETMASK, &servant_masks, NULL);
 
-	atexit(servant_exit);
-	servant_inform_parent = 1;
-
 	st = open_device(diskname, LOG_WARNING);
 	if (!st) {
-		return -1;
+		exit(EXIT_MD_IO_FAIL);
 	}
 
 	s_header = header_get(st);
 	if (!s_header) {
 		cl_log(LOG_ERR, "Not a valid header on %s", diskname);
-		return -1;
+		exit(EXIT_MD_IO_FAIL);
 	}
 
 	if (servant_check_timeout_inconsistent(s_header) < 0) {
 		cl_log(LOG_ERR, "Timeouts on %s do not match first device",
 				diskname);
-		return -1;
+		exit(EXIT_MD_IO_FAIL);
 	}
 
 	if (s_header->minor_version > 0) {
@@ -1102,14 +1084,14 @@ int servant(const char *diskname, int mode, const void* argp)
 		cl_log(LOG_ERR,
 		       "No slot allocated, and automatic allocation failed for disk %s.",
 		       diskname);
-		rc = -1;
+		rc = EXIT_MD_IO_FAIL;
 		goto out;
 	}
 	s_node = sector_alloc();
 	if (slot_read(st, mbox, s_node) < 0) {
 		cl_log(LOG_ERR, "Unable to read node entry on %s",
 				diskname);
-		exit(1);
+		exit(EXIT_MD_IO_FAIL);
 	}
 
 	DBGLOG(LOG_INFO, "Monitoring slot %d on disk %s", mbox, diskname);
@@ -1125,7 +1107,7 @@ int servant(const char *diskname, int mode, const void* argp)
 		if (mode > 0) {
 			if (mbox_read(st, mbox, s_mbox) < 0) {
 				cl_log(LOG_ERR, "mbox read failed during start-up in servant.");
-				rc = -1;
+				rc = EXIT_MD_IO_FAIL;
 				goto out;
 			}
 			if (s_mbox->cmd != SBD_MSG_EXIT &&
@@ -1141,7 +1123,7 @@ int servant(const char *diskname, int mode, const void* argp)
 		DBGLOG(LOG_INFO, "First servant start - zeroing inbox");
 		memset(s_mbox, 0, sizeof(*s_mbox));
 		if (mbox_write(st, mbox, s_mbox) < 0) {
-			rc = -1;
+			rc = EXIT_MD_IO_FAIL;
 			goto out;
 		}
 	}
@@ -1170,28 +1152,28 @@ int servant(const char *diskname, int mode, const void* argp)
 		s_header_retry = header_get(st);
 		if (!s_header_retry) {
 			cl_log(LOG_ERR, "No longer found a valid header on %s", diskname);
-			exit(1);
+			exit(EXIT_MD_IO_FAIL);
 		}
 		if (memcmp(s_header, s_header_retry, sizeof(*s_header)) != 0) {
 			cl_log(LOG_ERR, "Header on %s changed since start-up!", diskname);
-			exit(1);
+			exit(EXIT_MD_IO_FAIL);
 		}
 		free(s_header_retry);
 
 		s_node_retry = sector_alloc();
 		if (slot_read(st, mbox, s_node_retry) < 0) {
 			cl_log(LOG_ERR, "slot read failed in servant.");
-			exit(1);
+			exit(EXIT_MD_IO_FAIL);
 		}
 		if (memcmp(s_node, s_node_retry, sizeof(*s_node)) != 0) {
 			cl_log(LOG_ERR, "Node entry on %s changed since start-up!", diskname);
-			exit(1);
+			exit(EXIT_MD_IO_FAIL);
 		}
 		free(s_node_retry);
 
 		if (mbox_read(st, mbox, s_mbox) < 0) {
 			cl_log(LOG_ERR, "mbox read failed in servant.");
-			exit(1);
+			exit(EXIT_MD_IO_FAIL);
 		}
 
 		if (s_mbox->cmd > 0) {
@@ -1206,17 +1188,14 @@ int servant(const char *diskname, int mode, const void* argp)
 				sigqueue(ppid, SIG_TEST, signal_value);
 				break;
 			case SBD_MSG_RESET:
-				do_reset();
-				break;
+				exit(EXIT_MD_REQUEST_RESET);
 			case SBD_MSG_OFF:
-				do_off();
-				break;
+				exit(EXIT_MD_REQUEST_SHUTOFF);
 			case SBD_MSG_EXIT:
 				sigqueue(ppid, SIG_EXITREQ, signal_value);
 				break;
 			case SBD_MSG_CRASHDUMP:
-				do_crashdump();
-				break;
+				exit(EXIT_MD_REQUEST_CRASHDUMP);
 			default:
 				/* FIXME:
 				   An "unknown" message might result
@@ -1247,10 +1226,7 @@ int servant(const char *diskname, int mode, const void* argp)
  out:
 	free(s_mbox);
 	close_device(st);
-	if (rc == 0) {
-		servant_inform_parent = 0;
-	}
-	return rc;
+	exit(rc);
 }
 
 

--- a/src/sbd-md.c
+++ b/src/sbd-md.c
@@ -833,7 +833,7 @@ int ping_via_slots(const char *name, struct servants_list_item *servants)
 					break;
 				} else {
 					s = lookup_servant_by_pid(pid);
-					if (s && sbd_is_disk(s)) {
+					if (sbd_is_disk(s)) {
 						servants_finished++;
 					}
 				}

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -191,3 +191,5 @@ extern int servant_health;
 void set_servant_health(enum pcmk_health state, int level, char const *format, ...) __attribute__ ((__format__ (__printf__, 3, 4)));
 
 bool sbd_is_disk(struct servants_list_item *servant);
+bool sbd_is_pcmk(struct servants_list_item *servant);
+bool sbd_is_cluster(struct servants_list_item *servant);

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -50,9 +50,14 @@
 #define SIG_EXITREQ  (SIGRTMIN + 2)	/* exit request to inquisitor */
 #define SIG_TEST     (SIGRTMIN + 3)	/* trigger self test */
 #define SIG_RESTART  (SIGRTMIN + 4)	/* trigger restart of all failed disk */
-#define SIG_IO_FAIL  (SIGRTMIN + 5)	/* the IO child requests to be considered failed */
-#define SIG_PCMK_UNHEALTHY  (SIGRTMIN + 6)
+#define SIG_PCMK_UNHEALTHY  (SIGRTMIN + 5)
 /* FIXME: should add dynamic check of SIG_XX >= SIGRTMAX */
+
+/* exit status for disk-servant */
+#define EXIT_MD_IO_FAIL             20
+#define EXIT_MD_REQUEST_RESET       21
+#define EXIT_MD_REQUEST_SHUTOFF     22
+#define EXIT_MD_REQUEST_CRASHDUMP   23
 
 #define HOG_CHAR	0xff
 #define SECTOR_NAME_MAX 63


### PR DESCRIPTION
As stated in the fix-commit:

If disk-servant does a sysrq-reset sbd-inquisitor has to
terminate so that the watchdog can supervise the sysrq-execution.
Otherwise it goes into a respawn-loop on sysrq-reset failing.

Till now inquisitor received an RT-Signal (sbd-custom name SIG_IO_FAIL) prior to disk-servant-child's SIGCHLD.
Disabled sending the SIG_IO_FAIL in cases where the disk-servant wants to trigger a reset (fenced by another node writing the reset-message to the message-slot on the shared disk).
Whenever now a SIGCHILD is received from a disk-servant-process without a SIG_IO_FAIL before it is assumed that a reset was requested and inquisitor exits without gracefully closing the watchdog so that whatever the disk-servant has triggered (sysrq) is observed by the hardware-watchdog.

Tests are definitely looking fine.
I just didn't find documentation telling if when using sigtimedwait to dispatch signals it can be 100%-assured that pending RT-Signals are dispatched before the SIGCHLD.
Unfortunately http://pubs.opengroup.org/onlinepubs/9699919799/functions/sigtimedwait.html is quite explicit.