### PR TITLE
Fix: Don't reboot if off is requested

### DIFF
--- a/src/sbd-common.c
+++ b/src/sbd-common.c
@@ -487,8 +487,10 @@ do_exit(char kind)
     } else {
         watchdog_close(false);
         sysrq_trigger(kind);
-        if(reboot(RB_AUTOBOOT) < 0) {
-            cl_perror("Reboot failed");
+        if (kind != 'o') {
+            if(reboot(RB_AUTOBOOT) < 0) {
+                cl_perror("Reboot failed");
+            }
         }
     }
 


### PR DESCRIPTION
Don't know what led to having the reboot there unconditionally.
But like this you get a shutoff if you request one.
And as for some hardware-watchdogs you can configure them
to shutoff instead of reboot it might be interesting to have the
equivalent there.