### PR TITLE
Fix: cluster-servant: check for corosync 2Node mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,8 @@ AM_PROG_CC_C_O
 PKG_CHECK_MODULES(glib, [glib-2.0])
 dnl PKG_CHECK_MODULES(libcoroipcc, [libcoroipcc])
 
+PKG_CHECK_MODULES(cmap, [libcmap], HAVE_cmap=1, HAVE_cmap=0)
+
 dnl pacemaker > 1.1.8
 PKG_CHECK_MODULES(pacemaker, [pacemaker, pacemaker-cib], HAVE_pacemaker=1, HAVE_pacemaker=0)
 
@@ -44,6 +46,11 @@ if test $HAVE_pacemaker = 0 -a $HAVE_pcmk = 0; then
     AC_MSG_ERROR(No package 'pacemaker' found)
 elif test $HAVE_pacemaker = 1; then
     CPPFLAGS="$CPPFLAGS $glib_CFLAGS $pacemaker_CFLAGS"
+    if test $HAVE_cmap = 0; then
+        AC_MSG_NOTICE(No package 'cmap' found)
+    else
+	CPPFLAGS="$CPPFLAGS $cmap_CFLAGS"
+    fi
 fi
 
 PKG_CHECK_MODULES(libxml, [libxml-2.0])
@@ -58,6 +65,7 @@ AC_CHECK_LIB(pe_status, pe_find_node, , missing="yes")
 AC_CHECK_LIB(pe_rules, test_rule, , missing="yes")
 AC_CHECK_LIB(crmcluster, crm_peer_init, , missing="yes")
 AC_CHECK_LIB(uuid, uuid_unparse, , missing="yes")
+AC_CHECK_LIB(cmap, cmap_initialize, , HAVE_cmap=0)
 
 dnl pacemaker >= 1.1.8
 AC_CHECK_HEADERS(pacemaker/crm/cluster.h)
@@ -88,6 +96,9 @@ then
 	echo "/proc/{pid} is supported" 
 	AC_DEFINE_UNQUOTED(HAVE_PROC_PID, 1, Define to 1 if /proc/{pid} is supported.)
 fi
+
+AC_DEFINE_UNQUOTED(CHECK_TWO_NODE, $HAVE_cmap, Turn on checking for 2-node cluster)
+AM_CONDITIONAL(CHECK_TWO_NODE, test "$HAVE_cmap" = "1")
 
 CONFIGDIR=""
 AC_ARG_WITH(configdir,


### PR DESCRIPTION
Quick and simple approach for tackling the issue that sbd won't suicide when loosing disk & 2nd node on a 2Node cluster.
