### PR TITLE
travis: add regressions.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,9 @@ install: true
 
 script:
   - make -f Makefile.am spec export PACKAGE=${PACKAGE}
+  - docker pull ${DOCKER_BUILD_IMAGE}:${OS_TYPE}-${OS_VERSION}
   - docker run -v ${PWD}:/sources -v ${PWD}:/output ${DOCKER_BUILD_IMAGE}:${OS_TYPE}-${OS_VERSION}
   - ls ${PWD}/sbd*.${OS_ARCH}.rpm
+  - docker pull ${OS_TYPE}:${OS_TYPE}${OS_VERSION}
+  - docker run --privileged -v ${PWD}:/rpms -v ${PWD}/tests:/tests ${OS_TYPE}:${OS_TYPE}${OS_VERSION} /bin/bash -c "yum install -y device-mapper /rpms/${PACKAGE}*.${OS_ARCH}.rpm && /tests/regressions.sh && touch /rpms/regressions.sh.SUCCESS"
+  - ls ${PWD}/regressions.sh.SUCCESS

--- a/tests/regressions.sh
+++ b/tests/regressions.sh
@@ -36,6 +36,7 @@ sbd_setup() {
 		losetup ${L[$N]} ${F[$N]}
 		D[$N]="/dev/mapper/sbd_$N"
 		dmsetup create sbd_$N --table "0 2048 linear ${L[$N]} 0"
+		dmsetup mknodes sbd_$N
 	done
 }
 
@@ -63,7 +64,7 @@ _ok() {
 	rc=$?
 	if [ $rc -ne 0 ]; then
 		echo "$@ failed with $rc"
-		exit
+		exit $rc
 	fi
 }
 
@@ -73,7 +74,7 @@ _no() {
 	rc=$?
 	if [ $rc -eq 0 ]; then
 		echo "$@ did NOT fail ($rc)"
-		exit
+		exit $rc
 	fi
 	return 0
 }


### PR DESCRIPTION
Obviously udev doesn't trigger creation of files under /dev/mapper
inside privileged docker container - do it manually.
Make regressions.sh exit with an error-code to make it easier
for travis.