### PR TITLE
Add commands to test/query watchdogs

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -819,6 +819,7 @@ int main(int argc, char **argv, char **envp)
 	}
 
         watchdogdev = strdup("/dev/watchdog");
+        watchdogdev_is_default = true;
         qb_facility = qb_log_facility2int("daemon");
         qb_log_init(cmdname, qb_facility, LOG_WARNING);
         sbd_set_format_string(QB_LOG_SYSLOG, "sbd");
@@ -864,6 +865,7 @@ int main(int argc, char **argv, char **envp)
         if(value) {
             free(watchdogdev);
             watchdogdev = strdup(value);
+            watchdogdev_is_default = false;
         }
 
         value = getenv("SBD_WATCHDOG_TIMEOUT");
@@ -931,6 +933,7 @@ int main(int argc, char **argv, char **envp)
                         cl_log(LOG_NOTICE, "Using watchdog device '%s'", watchdogdev);
                         free(watchdogdev);
                         watchdogdev = strdup(optarg);
+                        watchdogdev_is_default = false;
 			break;
 		case 'd':
 #if SUPPORT_SHARED_DISK
@@ -1083,8 +1086,12 @@ int main(int argc, char **argv, char **envp)
 		exit_status = -2;
 	}
 #endif
-        
-        if (strcmp(argv[optind], "watch") == 0) {
+
+        if (strcmp(argv[optind], "query-watchdog") == 0) {
+            exit_status = watchdog_info();
+        } else if (strcmp(argv[optind], "test-watchdog") == 0) {
+            exit_status = watchdog_test();
+        } else if (strcmp(argv[optind], "watch") == 0) {
             /* sleep $(sbd $SBD_DEVICE_ARGS dump | grep -m 1 msgwait | awk '{print $4}') 2>/dev/null */
 
                 /* We only want this to have an effect during watch right now;

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -124,6 +124,8 @@ int watchdog_tickle(void);
 int watchdog_init(void);
 void sysrq_init(void);
 void watchdog_close(bool disarm);
+int watchdog_info(void);
+int watchdog_test(void);
 void sysrq_trigger(char t);
 void do_crashdump(void);
 void do_reset(void);
@@ -149,6 +151,7 @@ extern int  skip_rt;
 extern int  debug;
 extern int  debug_mode;
 extern char *watchdogdev;
+extern bool watchdogdev_is_default;
 extern char*  local_uname;
 
 /* Global, non-tunable variables: */


### PR DESCRIPTION
refactored watchdog functions to be based on parameters instead of global config

todo: watchdog-drivers missing /sys/dev/char/10:130/device/driver don't show a proper driver

Some output examples:
```
>> sbd query-watchdog

Discovered 5 watchdog devices:

[1] /dev/watchdog1
Identity: iTCO_wdt
Driver: iTCO_wdt

[2] /dev/watchdog2
Identity: Software Watchdog
Driver: softdog
CAUTION: Not recommended for use with sbd.

[3] /dev/watchdog
Identity: iamt_wdt
Driver: mei_wdt

[4] /dev/watchdog0
Identity: iamt_wdt
Driver: mei_wdt

[5] /dev/watchdog_link
Identity: iamt_wdt
Driver: mei_wdt

>> sbd -w /dev/watchdog test-watchdog

WARNING: This operation is expected to force-reboot this system
         without following any shutdown procedures.

Proceed? [NO/Proceed] Proceed

Initializing /dev/watchdog with a reset countdown of 5 seconds ...

NOTICE: The watchdog device is expected to reset the system
        in 5 seconds.  If system remains active beyond that time,
        watchdog may not be functional.

Reset countdown ... 5 seconds
Reset countdown ... 4 seconds
Reset countdown ... 3 seconds
Reset countdown ... 2 seconds
System expected to reset any moment ...
System expected to reset any moment ...

>> sbd --help
......
Commands:
create		initialize N slots on <dev> - OVERWRITES DEVICE!
list		List all allocated slots on device, and messages.
dump		Dump meta-data header from device.
allocate <node>
		Allocate a slot for node (optional)
message <node> (test|reset|off|clear|exit)
		Writes the specified message to node's slot.
watch		Loop forever, monitoring own slot
query-watchdog	Check for available watchdog-devices and print some info
test-watchdog	Test the watchdog-device selected.
		Attention: This will arm the watchdog and have your system reset
		           in case your watchdog is working properly!
```