### PR TITLE
Fix: gcc format string error

### DIFF
--- a/src/sbd-common.c
+++ b/src/sbd-common.c
@@ -268,7 +268,7 @@ watchdog_populate_list(void)
 		{makedev(10,130), 0};
 	int num_watchdogs = 1;
 	struct dirent *entry;
-	char entry_name[64];
+	char entry_name[280];
 	DIR *dp;
 	char buf[256] = "";
 


### PR DESCRIPTION
Increase buffer size to fix the following error when building using gcc 7.2.1 on Debian:

```
gcc -DHAVE_CONFIG_H -I. -I..  -I/usr/include/pacemaker -I/usr/include/heartbeat -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -Wdate-time -D_FORTIFY_SOURCE=2 -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/pacemaker  -I/usr/include/libxml2  -D_GNU_SOURCE -DCHECK_AIS -DSBINDIR=\"/usr/sbin\" -g -O2 -fdebug-prefix-map=/home/vvidic/work/scm/debian-ha/sbd=. -fstack-protector-strong -Wformat -Werror=format-security -I/usr/include/x86_64-linux-gnu/pacemaker -c -o sbd-md.o sbd-md.c
sbd-common.c: In function ‘watchdog_populate_list’:
sbd-common.c:249:28: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 44 [-Werror=format-truncation=]
 #define SYS_CLASS_WATCHDOG "/sys/class/watchdog"
                            ^
sbd-common.c:287:7: note: in expansion of macro ‘SYS_CLASS_WATCHDOG’
       SYS_CLASS_WATCHDOG "/%s/dev", entry->d_name);
       ^~~~~~~~~~~~~~~~~~
sbd-common.c:287:28: note: format string is defined here
       SYS_CLASS_WATCHDOG "/%s/dev", entry->d_name);
                            ^~
In file included from /usr/include/stdio.h:938:0,
                 from /usr/include/malloc.h:24,
                 from sbd.h:28,
                 from sbd-common.c:19:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 25 and 280 bytes into a destination of size 64
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sbd-common.c:251:26: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 59 [-Werror=format-truncation=]
 #define WATCHDOG_NODEDIR "/dev"
                          ^
sbd-common.c:313:7: note: in expansion of macro ‘WATCHDOG_NODEDIR’
       WATCHDOG_NODEDIR "/%s", entry->d_name);
       ^~~~~~~~~~~~~~~~
sbd-common.c:313:26: note: format string is defined here
       WATCHDOG_NODEDIR "/%s", entry->d_name);
                          ^~
In file included from /usr/include/stdio.h:938:0,
                 from /usr/include/malloc.h:24,
                 from sbd.h:28,
                 from sbd-common.c:19:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 6 and 261 bytes into a destination of size 64
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
Makefile:397: recipe for target 'sbd-common.o' failed
make[3]: *** [sbd-common.o] Error 1
```
