### PR TITLE
Fix: build error with glibc 2.25

### DIFF
--- a/src/sbd-common.c
+++ b/src/sbd-common.c
@@ -19,6 +19,7 @@
 #include "sbd.h"
 #include <sys/reboot.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <pwd.h>
 #include <unistd.h>

--- a/src/sbd-common.c
+++ b/src/sbd-common.c
@@ -19,7 +19,9 @@
 #include "sbd.h"
 #include <sys/reboot.h>
 #include <sys/types.h>
+#ifdef __GLIBC__
 #include <sys/sysmacros.h>
+#endif
 #include <sys/stat.h>
 #include <pwd.h>
 #include <unistd.h>


### PR DESCRIPTION
Add include for makedev, major and minor.

```
sbd-common.c:268:13: error: In the GNU C Library, "makedev" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "makedev", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "makedev", you should undefine it after including <sys/types.h>. [-Werror]
   {makedev(10,130), 0};
```