### PR TITLE
Build: cluster-servant: Compile with pacemaker-2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,10 @@ AC_CHECK_HEADERS(pacemaker/crm/cluster.h)
 AC_CHECK_LIB(crmcommon, pcmk_strerror, , missing="yes")
 AC_CHECK_LIB(cib, cib_apply_patch_event, , missing="yes")
 
+dnl pacemaker-2.0 removed support for corosync 1 cluster layer
+AC_CHECK_DECLS([pcmk_cluster_classic_ais, pcmk_cluster_cman],,,
+	       [#include <pacemaker/crm/cluster.h>])
+
 if test "$missing" = "yes"; then
    AC_MSG_ERROR([Missing required libraries or functions.])
 fi

--- a/src/sbd-cluster.c
+++ b/src/sbd-cluster.c
@@ -238,12 +238,16 @@ notify_timer_cb(gpointer data)
     }
 
     switch (get_cluster_type()) {
+#if HAVE_DECL_PCMK_CLUSTER_CLASSIC_AIS
         case pcmk_cluster_classic_ais:
             send_cluster_text(crm_class_quorum, NULL, TRUE, NULL, crm_msg_ais);
             break;
 
+#endif
         case pcmk_cluster_corosync:
+#if HAVE_DECL_PCMK_CLUSTER_CMAN
         case pcmk_cluster_cman:
+#endif
             /* TODO - Make a CPG call and only call notify_parent() when we get a reply */
             notify_parent();
             break;


### PR DESCRIPTION
Pacemaker-2.0 removed support for corosync 1 cluster layer:
https://github.com/ClusterLabs/pacemaker/commit/7a9891f29