### PR TITLE
Startup issues

### DIFF
--- a/src/sbd.service.in
+++ b/src/sbd.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Shared-storage based fencing daemon
 Before=pacemaker.service
+Before=dlm.service
 After=systemd-modules-load.service iscsi.service
 PartOf=corosync.service
 RefuseManualStop=true
@@ -22,4 +23,5 @@ Restart=on-abort
 
 [Install]
 RequiredBy=corosync.service
-
+RequiredBy=pacemaker.service
+RequiredBy=dlm.service

--- a/src/sbd.sysconfig
+++ b/src/sbd.sysconfig
@@ -31,6 +31,9 @@ SBD_STARTMODE=always
 # other nodes are still waiting in the fence acknowledgement phase.
 # This is an occasional issue with virtual machines.
 #
+# Consider that you might have to adapt the startup-timeout accordingly
+# if the default isn't sufficient. (TimeoutStartSec for systemd)
+#
 # This option may be ignored at a later point, once pacemaker handles
 # this case better.
 #

--- a/src/sbd_remote.service.in
+++ b/src/sbd_remote.service.in
@@ -21,4 +21,4 @@ Restart=on-abort
 
 [Install]
 RequiredBy=pacemaker_remote.service
-
+RequiredBy=dlm.service


### PR DESCRIPTION
Fixes the issue we recently discussed on the clusterlabs-list that sbd failing to start didn't prevent pacemaker from coming up.
This is kind of severe as pacemaker would run without supervision by sbd, watchdog would possibly not be armed and the poison-pill wouldn't be read from the storage.
What led to this finding was systemd timing out on trying to start sbd when SBD_DELAY_START is enabled and msgwait > default startup-timeout.
Thus I added some reminder to check for the timeout to sbd.sysconfig.

In the code - right before enabling the watchdog it says:
```
/* We only do this at the point either the disk or
 * cluster servants become healthy
 */
```
In case of having no disks configured this would mean that my patch would create a deadlock.
But fortunately this comment seems to be a leftover. In the case without disks it still does detach from
the main-process - enabling the watchdog in the course of this - but it doesn't trigger as long as
there is no cluster.
So everything should be fine so that once systemd detects proper start of sbd it should be assured that the watchdog could be opened.