### PR TITLE
Fix: systemd: reenable on upgrades to have dependency links updated

### DIFF
--- a/sbd.spec
+++ b/sbd.spec
@@ -90,6 +90,10 @@ rm -rf %{buildroot}
 %post
 %systemd_post sbd.service
 %systemd_post sbd_remote.service
+if [ $1 -ne 1 ] ; then
+	systemctl is-enabled sbd && systemctl reenable sbd
+	systemctl is-enabled sbd_remote && systemctl reenable sbd_remote
+fi
 
 %preun
 %systemd_preun sbd.service


### PR DESCRIPTION
We've recently added a stronger dependency between pacemaker & sbd to prevent pacemaker from coming up while sbd is failing.
To be able to benefit from this behavior one had to enable the sbd-service just after installation of the updated unit-file (reenable if it was already enabled before).
With this fix sbd-service is automatically reenabled upon upgrades if it was enabled before.
Caveat: Any manually created dependency-links under /etc/systemd/system pointing to sbd will get deleted.

