### PR TITLE
Log: change sbd's default logging level to LOG_NOTICE

### DIFF
--- a/src/sbd-cluster.c
+++ b/src/sbd-cluster.c
@@ -201,10 +201,11 @@ sbd_get_two_node(void)
     }
 
     if (cmap_get_uint8(cmap_handle, "quorum.two_node", &two_node_u8) == CS_OK) {
-        cl_log(LOG_NOTICE, "Corosync is%s in 2Node-mode", two_node_u8?"":" not");
+        cl_log(two_node_u8? LOG_NOTICE : LOG_INFO,
+               "Corosync is%s in 2Node-mode", two_node_u8?"":" not");
         two_node = two_node_u8;
     } else {
-        cl_log(LOG_NOTICE, "quorum.two_node present in cmap\n");
+        cl_log(LOG_INFO, "quorum.two_node not present in cmap\n");
     }
     return TRUE;
 
@@ -264,7 +265,7 @@ sbd_membership_connect(void)
 {
     bool connected = false;
 
-    cl_log(LOG_NOTICE, "Attempting cluster connection");
+    cl_log(LOG_INFO, "Attempting cluster connection");
 
     cluster.destroy = sbd_membership_destroy;
 
@@ -308,7 +309,7 @@ sbd_membership_connect(void)
         }
     }
 
-    set_servant_health(pcmk_health_transient, LOG_NOTICE, "Connected, waiting for initial membership");
+    set_servant_health(pcmk_health_transient, LOG_INFO, "Connected, waiting for initial membership");
     notify_parent();
 
     notify_timer_cb(NULL);
@@ -530,7 +531,7 @@ servant_cluster(const char *diskname, int mode, const void* argp)
     enum cluster_type_e cluster_stack = get_cluster_type();
 
     crm_system_name = strdup("sbd:cluster");
-    cl_log(LOG_INFO, "Monitoring %s cluster health", name_for_cluster_type(cluster_stack));
+    cl_log(LOG_NOTICE, "Monitoring %s cluster health", name_for_cluster_type(cluster_stack));
     set_proc_title("sbd: watcher: Cluster");
 
     sbd_membership_connect();

--- a/src/sbd-common.c
+++ b/src/sbd-common.c
@@ -893,7 +893,7 @@ notify_parent(void)
         case pcmk_health_pending:
         case pcmk_health_shutdown:
         case pcmk_health_transient:
-            DBGLOG(LOG_INFO, "Not notifying parent: state transient (%d)", servant_health);
+            DBGLOG(LOG_DEBUG, "Not notifying parent: state transient (%d)", servant_health);
             break;
 
         case pcmk_health_unknown:
@@ -904,7 +904,7 @@ notify_parent(void)
             break;
 
         case pcmk_health_online:
-            DBGLOG(LOG_INFO, "Notifying parent: healthy");
+            DBGLOG(LOG_DEBUG, "Notifying parent: healthy");
             sigqueue(ppid, SIG_LIVENESS, signal_value);
             break;
 

--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -803,6 +803,19 @@ parse_device_line(const char *line)
     return found;
 }
 
+#define SBD_SOURCE_FILES "sbd-cluster.c,sbd-common.c,sbd-inquisitor.c,sbd-md.c,sbd-pacemaker.c,setproctitle.c"
+
+static void
+sbd_log_filter_ctl(const char *files, uint8_t priority)
+{
+	if (files == NULL) {
+		files = SBD_SOURCE_FILES;
+	}
+
+	qb_log_filter_ctl(QB_LOG_SYSLOG, QB_LOG_FILTER_ADD, QB_LOG_FILTER_FILE, files, priority);
+	qb_log_filter_ctl(QB_LOG_STDERR, QB_LOG_FILTER_ADD, QB_LOG_FILTER_FILE, files, priority);
+}
+
 int
 arg_enabled(int arg_count)
 {
@@ -834,6 +847,7 @@ int main(int argc, char **argv, char **envp)
 
         qb_log_ctl(QB_LOG_SYSLOG, QB_LOG_CONF_ENABLED, QB_TRUE);
         qb_log_ctl(QB_LOG_STDERR, QB_LOG_CONF_ENABLED, QB_FALSE);
+        sbd_log_filter_ctl(NULL, LOG_NOTICE);
 
 	sbd_get_uname();
 
@@ -926,15 +940,17 @@ int main(int argc, char **argv, char **envp)
 		case 'v':
                     debug++;
                     if(debug == 1) {
-                        qb_log_filter_ctl(QB_LOG_SYSLOG, QB_LOG_FILTER_ADD, QB_LOG_FILTER_FILE, "sbd-common.c,sbd-inquisitor.c,sbd-md.c,sbd-pacemaker.c", LOG_DEBUG);
-                        qb_log_filter_ctl(QB_LOG_STDERR, QB_LOG_FILTER_ADD, QB_LOG_FILTER_FILE, "sbd-common.c,sbd-inquisitor.c,sbd-md.c,sbd-pacemaker.c", LOG_DEBUG);
-			cl_log(LOG_INFO, "Verbose mode enabled.");
+                        sbd_log_filter_ctl(NULL, LOG_INFO);
+                        cl_log(LOG_INFO, "Verbose mode enabled.");
 
                     } else if(debug == 2) {
+                        sbd_log_filter_ctl(NULL, LOG_DEBUG);
+                        cl_log(LOG_INFO, "Debug mode enabled.");
+
+                    } else if(debug == 3) {
                         /* Go nuts, turn on pacemaker's logging too */
-                        qb_log_filter_ctl(QB_LOG_SYSLOG, QB_LOG_FILTER_ADD, QB_LOG_FILTER_FILE, "*", LOG_DEBUG);
-                        qb_log_filter_ctl(QB_LOG_STDERR, QB_LOG_FILTER_ADD, QB_LOG_FILTER_FILE, "*", LOG_DEBUG);
-			cl_log(LOG_INFO, "Verbose library mode enabled.");
+                        sbd_log_filter_ctl("*", LOG_DEBUG);
+                        cl_log(LOG_INFO, "Debug library mode enabled.");
                     }
                     break;
 		case 'T':

--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -64,7 +64,7 @@ void recruit_servant(const char *devname, pid_t pid)
 
 	servant_count++;
         if(sbd_is_disk(newbie)) {
-            cl_log(LOG_NOTICE, "Monitoring %s", devname);
+            cl_log(LOG_INFO, "Monitoring %s", devname);
             disk_count++;
         } else {
             newbie->outdated = 1;
@@ -565,7 +565,7 @@ void inquisitor_child(void)
                     if(cluster_alive(true)) {
                         /* We LIVE! */
                         if(cluster_appeared == false) {
-                            cl_log(LOG_NOTICE, "Active cluster detected");
+                            cl_log(LOG_INFO, "Active cluster detected");
                         }
                         tickle = 1;
                         can_detach = 1;
@@ -574,7 +574,7 @@ void inquisitor_child(void)
                     } else if(cluster_alive(false)) {
                         if(!decoupled) {
                             /* On the way up, detach and arm the watchdog */
-                            cl_log(LOG_NOTICE, "Partial cluster detected, detaching");
+                            cl_log(LOG_INFO, "Partial cluster detected, detaching");
                         }
 
                         can_detach = 1;

--- a/src/sbd-md.c
+++ b/src/sbd-md.c
@@ -1097,7 +1097,7 @@ int servant(const char *diskname, int mode, const void* argp)
 		exit(EXIT_MD_IO_FAIL);
 	}
 
-	DBGLOG(LOG_INFO, "Monitoring slot %d on disk %s", mbox, diskname);
+	cl_log(LOG_NOTICE, "Monitoring slot %d on disk %s", mbox, diskname);
 	if (s_header->minor_version == 0) {
 		set_proc_title("sbd: watcher: %s - slot: %d", diskname, mbox);
 	} else {
@@ -1180,7 +1180,7 @@ int servant(const char *diskname, int mode, const void* argp)
 		}
 
 		if (s_mbox->cmd > 0) {
-			cl_log(LOG_INFO,
+			cl_log(LOG_NOTICE,
 			       "Received command %s from %s on disk %s",
 			       char2cmd(s_mbox->cmd), s_mbox->from, diskname);
 
@@ -1222,7 +1222,7 @@ int servant(const char *diskname, int mode, const void* argp)
 			       (int)latency, (int)timeout_watchdog_warn,
 			       diskname);
 		} else if (debug) {
-			DBGLOG(LOG_INFO, "Latency: %d on disk %s", (int)latency,
+			DBGLOG(LOG_DEBUG, "Latency: %d on disk %s", (int)latency,
 			       diskname);
 		}
 	}

--- a/src/sbd-pacemaker.c
+++ b/src/sbd-pacemaker.c
@@ -416,7 +416,7 @@ servant_pcmk(const char *diskname, int mode, const void* argp)
 	int exit_code = 0;
 
         crm_system_name = strdup("sbd:pcmk");
-	cl_log(LOG_INFO, "Monitoring Pacemaker health");
+	cl_log(LOG_NOTICE, "Monitoring Pacemaker health");
 	set_proc_title("sbd: watcher: Pacemaker");
         setenv("PCMK_watchdog", "true", 1);
 


### PR DESCRIPTION
With the refactoring of logging parts and 1ee3503, sbd became too
silent given the default logging level LOG_WARNING, even under the
situations where it's supposed to tell something.

This commit changes sbd's default logging level to LOG_NOTICE.
Meanwhile pacemaker library's logging level remains at LOG_WARNING.
With "-v", sbd's logging level is set to LOG_INFO.
With "-vv", sbd's logging level is set to LOG_DEBUG.
With "-vvv", both sbd's and pacemaker library's logging levels are set
to LOG_DEBUG.

It also upgrades important messages and downgrades unimportant ones.