### PR TITLE
Fix: sbd-md: return error if faied to list any devices

### DIFF
--- a/src/sbd-md.c
+++ b/src/sbd-md.c
@@ -790,18 +790,22 @@ int list_slots(struct servants_list_item *servants)
 	struct sbd_context *st;
 
 	for (s = servants; s; s = s->next) {
+		int rv  = 0;
+
 		st = open_device(s->devname, LOG_WARNING);
 		if (!st) {
+			rc = -1;
 			fprintf(stdout, "== disk %s unreadable!\n", s->devname);
 			continue;
 		}
-		rc = slot_list(st);
+		rv = slot_list(st);
 		close_device(st);
-		if (rc == -1) {
+		if (rv == -1) {
+			rc = -1;
 			fprintf(stdout, "== Slots on disk %s NOT dumped\n", s->devname);
 		}
 	}
-	return 0;
+	return rc;
 }
 
 int ping_via_slots(const char *name, struct servants_list_item *servants)


### PR DESCRIPTION
Based on the patch from Lidong Zhong <lidong.zhong@suse.com>

With this change, when using the lha stonith agent
"stonith:external/sbd", stonith resource will report errors rather than
be quiet if any sbd devices failed, so that users can realize. And it
won't trigger deregistration of the fencing device from
pacemaker-fenced, which makes sense -- We should try hard to use a
fencing device if there's any chance. If it really doesn't work,
it'll fail to fence then.

The issue was originally brought up from:
https://github.com/ClusterLabs/sbd/pull/40#issuecomment-353266808

Another possible solution of considering to return positive if a quorate
number of devices can be listed properly was suggested.

However so far all the "command" functions consistently return -1 when
failed, and then sbd consistently returns 1 as error for all the
commands.

We'd probably better not break the convention unless it's very necessary.