### PR TITLE
Doc: sbd.sysconfig: SBD_WATCHDOG_TIMEOUT is applicable only for diskless mode

### DIFF
--- a/src/sbd.sysconfig
+++ b/src/sbd.sysconfig
@@ -61,12 +61,9 @@ SBD_WATCHDOG_DEV=/dev/watchdog
 # How long, in seconds, the watchdog will wait before panicing the
 # node if no-one tickles it.
 #
-# This depends mostly on your storage latency; the majority of devices
-# must be successfully read within this time, or else the node will
-# self-fence.
-#
-# If your sbd device(s) reside on a multipath setup or iSCSI, this
-# should be the time required to detect a path failure.
+# This environment variable is applicable only for diskless mode.
+# For sbd with shared disk, watchdog timeout is determined by on-disk
+# metadata which can be set by creating sbd device with "-1" option.
 #
 SBD_WATCHDOG_TIMEOUT=5
 


### PR DESCRIPTION
Environment variable SBD_WATCHDOG_TIMEOUT is applicable only for diskless mode.
For sbd with shared disk, watchdog timeout is determined by on-disk
metadata which can be set by creating sbd device with "-1" option.