### PR TITLE
Fix: sbd-cluster: finalize cmap connection if disconnected from cluster

### DIFF
--- a/src/sbd-cluster.c
+++ b/src/sbd-cluster.c
@@ -174,6 +174,25 @@ cmap_dispatch_callback (gpointer user_data)
     return TRUE;
 }
 
+static void
+cmap_destory(void)
+{
+    if (cmap_source) {
+        g_source_destroy(cmap_source);
+        cmap_source = NULL;
+    }
+
+    if (track_handle) {
+        cmap_track_delete(cmap_handle, track_handle);
+        track_handle = 0;
+    }
+
+    if (cmap_handle) {
+        cmap_finalize(cmap_handle);
+        cmap_handle = 0;
+    }
+}
+
 static gboolean
 sbd_get_two_node(void)
 {
@@ -217,18 +236,7 @@ sbd_get_two_node(void)
     return TRUE;
 
 out:
-    if (cmap_source) {
-        g_source_destroy(cmap_source);
-        cmap_source = NULL;
-    }
-    if (track_handle) {
-        cmap_track_delete(cmap_handle, track_handle);
-        track_handle = 0;
-    }
-    if (cmap_handle) {
-        cmap_finalize(cmap_handle);
-        cmap_handle = 0;
-    }
+    cmap_destory();
 
     return FALSE;
 }
@@ -326,6 +334,12 @@ static void
 sbd_membership_destroy(gpointer user_data)
 {
     cl_log(LOG_WARNING, "Lost connection to %s", name_for_cluster_type(get_cluster_type()));
+
+    if (get_cluster_type() != pcmk_cluster_unknown) {
+#if SUPPORT_COROSYNC && CHECK_TWO_NODE
+        cmap_destory();
+#endif
+    }
 
     set_servant_health(pcmk_health_unclean, LOG_ERR, "Cluster connection terminated");
     notify_parent();


### PR DESCRIPTION
Previously if sbd cluster servant anyhow got dis-/reconnected from the
cluster, it'd start hogging cpu keeping polling the old main loop
source of cmap.