### PR TITLE
Fix: sbd-pacemaker: make handling of cib-connection loss more robust

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -490,21 +490,37 @@ void inquisitor_child(void)
 					if (sbd_is_disk(s)) {
 						if (WIFEXITED(status)) {
 							switch(WEXITSTATUS(status)) {
-								case EXIT_MD_IO_FAIL:
+								case EXIT_MD_SERVANT_IO_FAIL:
 									DBGLOG(LOG_INFO, "Servant for %s requests to be disowned",
 										s->devname);
 									break;
-								case EXIT_MD_REQUEST_RESET:
+								case EXIT_MD_SERVANT_REQUEST_RESET:
 									cl_log(LOG_WARNING, "%s requested a reset", s->devname);
 									do_reset();
 									break;
-								case EXIT_MD_REQUEST_SHUTOFF:
+								case EXIT_MD_SERVANT_REQUEST_SHUTOFF:
 									cl_log(LOG_WARNING, "%s requested a shutoff", s->devname);
 									do_off();
 									break;
-								case EXIT_MD_REQUEST_CRASHDUMP:
+								case EXIT_MD_SERVANT_REQUEST_CRASHDUMP:
 									cl_log(LOG_WARNING, "%s requested a crashdump", s->devname);
 									do_crashdump();
+									break;
+								default:
+									break;
+							}
+						}
+					} else if (sbd_is_pcmk(s)) {
+						if (WIFEXITED(status)) {
+							switch(WEXITSTATUS(status)) {
+								case EXIT_PCMK_SERVANT_GRACEFUL_SHUTDOWN:
+									DBGLOG(LOG_INFO, "PCMK-Servant has exited gracefully");
+									/* revert to state prior to pacemaker-detection */
+									s->restarts = 0;
+									s->restart_blocked = 0;
+									cluster_appeared = 0;
+									s->outdated = 1;
+									s->t_last.tv_sec = 0;
 									break;
 								default:
 									break;

--- a/src/sbd-md.c
+++ b/src/sbd-md.c
@@ -1061,19 +1061,19 @@ int servant_md(const char *diskname, int mode, const void* argp)
 
 	st = open_device(diskname, LOG_WARNING);
 	if (!st) {
-		exit(EXIT_MD_IO_FAIL);
+		exit(EXIT_MD_SERVANT_IO_FAIL);
 	}
 
 	s_header = header_get(st);
 	if (!s_header) {
 		cl_log(LOG_ERR, "Not a valid header on %s", diskname);
-		exit(EXIT_MD_IO_FAIL);
+		exit(EXIT_MD_SERVANT_IO_FAIL);
 	}
 
 	if (servant_check_timeout_inconsistent(s_header) < 0) {
 		cl_log(LOG_ERR, "Timeouts on %s do not match first device",
 				diskname);
-		exit(EXIT_MD_IO_FAIL);
+		exit(EXIT_MD_SERVANT_IO_FAIL);
 	}
 
 	if (s_header->minor_version > 0) {
@@ -1086,14 +1086,14 @@ int servant_md(const char *diskname, int mode, const void* argp)
 		cl_log(LOG_ERR,
 		       "No slot allocated, and automatic allocation failed for disk %s.",
 		       diskname);
-		rc = EXIT_MD_IO_FAIL;
+		rc = EXIT_MD_SERVANT_IO_FAIL;
 		goto out;
 	}
 	s_node = sector_alloc();
 	if (slot_read(st, mbox, s_node) < 0) {
 		cl_log(LOG_ERR, "Unable to read node entry on %s",
 				diskname);
-		exit(EXIT_MD_IO_FAIL);
+		exit(EXIT_MD_SERVANT_IO_FAIL);
 	}
 
 	cl_log(LOG_NOTICE, "Monitoring slot %d on disk %s", mbox, diskname);
@@ -1109,7 +1109,7 @@ int servant_md(const char *diskname, int mode, const void* argp)
 		if (mode > 0) {
 			if (mbox_read(st, mbox, s_mbox) < 0) {
 				cl_log(LOG_ERR, "mbox read failed during start-up in servant.");
-				rc = EXIT_MD_IO_FAIL;
+				rc = EXIT_MD_SERVANT_IO_FAIL;
 				goto out;
 			}
 			if (s_mbox->cmd != SBD_MSG_EXIT &&
@@ -1125,7 +1125,7 @@ int servant_md(const char *diskname, int mode, const void* argp)
 		DBGLOG(LOG_INFO, "First servant start - zeroing inbox");
 		memset(s_mbox, 0, sizeof(*s_mbox));
 		if (mbox_write(st, mbox, s_mbox) < 0) {
-			rc = EXIT_MD_IO_FAIL;
+			rc = EXIT_MD_SERVANT_IO_FAIL;
 			goto out;
 		}
 	}
@@ -1154,28 +1154,28 @@ int servant_md(const char *diskname, int mode, const void* argp)
 		s_header_retry = header_get(st);
 		if (!s_header_retry) {
 			cl_log(LOG_ERR, "No longer found a valid header on %s", diskname);
-			exit(EXIT_MD_IO_FAIL);
+			exit(EXIT_MD_SERVANT_IO_FAIL);
 		}
 		if (memcmp(s_header, s_header_retry, sizeof(*s_header)) != 0) {
 			cl_log(LOG_ERR, "Header on %s changed since start-up!", diskname);
-			exit(EXIT_MD_IO_FAIL);
+			exit(EXIT_MD_SERVANT_IO_FAIL);
 		}
 		free(s_header_retry);
 
 		s_node_retry = sector_alloc();
 		if (slot_read(st, mbox, s_node_retry) < 0) {
 			cl_log(LOG_ERR, "slot read failed in servant.");
-			exit(EXIT_MD_IO_FAIL);
+			exit(EXIT_MD_SERVANT_IO_FAIL);
 		}
 		if (memcmp(s_node, s_node_retry, sizeof(*s_node)) != 0) {
 			cl_log(LOG_ERR, "Node entry on %s changed since start-up!", diskname);
-			exit(EXIT_MD_IO_FAIL);
+			exit(EXIT_MD_SERVANT_IO_FAIL);
 		}
 		free(s_node_retry);
 
 		if (mbox_read(st, mbox, s_mbox) < 0) {
 			cl_log(LOG_ERR, "mbox read failed in servant.");
-			exit(EXIT_MD_IO_FAIL);
+			exit(EXIT_MD_SERVANT_IO_FAIL);
 		}
 
 		if (s_mbox->cmd > 0) {
@@ -1190,14 +1190,14 @@ int servant_md(const char *diskname, int mode, const void* argp)
 				sigqueue(ppid, SIG_TEST, signal_value);
 				break;
 			case SBD_MSG_RESET:
-				exit(EXIT_MD_REQUEST_RESET);
+				exit(EXIT_MD_SERVANT_REQUEST_RESET);
 			case SBD_MSG_OFF:
-				exit(EXIT_MD_REQUEST_SHUTOFF);
+				exit(EXIT_MD_SERVANT_REQUEST_SHUTOFF);
 			case SBD_MSG_EXIT:
 				sigqueue(ppid, SIG_EXITREQ, signal_value);
 				break;
 			case SBD_MSG_CRASHDUMP:
-				exit(EXIT_MD_REQUEST_CRASHDUMP);
+				exit(EXIT_MD_SERVANT_REQUEST_CRASHDUMP);
 			default:
 				/* FIXME:
 				   An "unknown" message might result

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -54,10 +54,13 @@
 /* FIXME: should add dynamic check of SIG_XX >= SIGRTMAX */
 
 /* exit status for disk-servant */
-#define EXIT_MD_IO_FAIL             20
-#define EXIT_MD_REQUEST_RESET       21
-#define EXIT_MD_REQUEST_SHUTOFF     22
-#define EXIT_MD_REQUEST_CRASHDUMP   23
+#define EXIT_MD_SERVANT_IO_FAIL             20
+#define EXIT_MD_SERVANT_REQUEST_RESET       21
+#define EXIT_MD_SERVANT_REQUEST_SHUTOFF     22
+#define EXIT_MD_SERVANT_REQUEST_CRASHDUMP   23
+
+/* exit status for pcmk-servant */
+#define EXIT_PCMK_SERVANT_GRACEFUL_SHUTDOWN 30
 
 #define HOG_CHAR	0xff
 #define SECTOR_NAME_MAX 63


### PR DESCRIPTION
Exit pcmk-servant on graceful pacemaker shutdown and go back
to state before pacemaker was detected initially.
Purge all cib-traces otherwise and try to reconnect within timeout.

The up-to-now-solution seems to be working more or less accidentially.
Especially since pacemaker-2.x a graceful shutdown of pacemaker leaving sbd & corosync alive quite often leads to a watchdog-reboot.
This approach is watching the cib and if the connection goes away after shutdown-state has been seen and subsequently all resources on the node are down it assumes a graceful pacemaker-shutdown.
On top the various timeouts are set to more reasonable values.

Effect should be both more reliable detection of graceful pacemaker shutdown (+ subsequent survival of the node) and enforced properly timeout-observed reconnection in other cases (cib restarted, pacemaker restarted, connection loss for other reasons).
  