### PR TITLE
Fix: sbd-inquisitor: Avoid flooding logs with messages that hint the default/configured timeout action

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -1175,8 +1175,6 @@ int main(int argc, char **argv, char **envp)
 			goto out;
 		}
 	}
-	cl_log(LOG_NOTICE, "%s flush + writing \'%c\' to sysrq on timeout",
-		do_flush?"Doing":"Skipping", timeout_sysrq_char);
 
 #if SUPPORT_SHARED_DISK
 	if (strcmp(argv[optind], "create") == 0) {
@@ -1238,6 +1236,8 @@ int main(int argc, char **argv, char **envp)
                         recruit_servant("cluster", 0);
                 }
 
+                cl_log(LOG_NOTICE, "%s flush + write \'%c\' to sysrq in case of timeout",
+                       do_flush?"Do":"Skip", timeout_sysrq_char);
                 exit_status = inquisitor();
         }
         


### PR DESCRIPTION
Previously with a monitor configured for sbd resource, the messages would
be flooding logs.

Probably the message doesn't necessarily belong to a notice, but in any
case it makes sense only for watch mode.

It's also rephrased a little since users were scared while seeing "...
writing 'b to sysrq ..." :-)