### PR TITLE
sbd-cluster: Simplify cluster connection loss handling

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -526,6 +526,20 @@ void inquisitor_child(void)
 									break;
 							}
 						}
+					} else if (sbd_is_cluster(s)) {
+						if (WIFEXITED(status)) {
+							switch(WEXITSTATUS(status)) {
+								case EXIT_CLUSTER_DISCONNECT:
+									cl_log(LOG_WARNING, "Cluster-Servant has exited (cluster connection lost)");
+									s->restarts = 0;
+									s->restart_blocked = 0;
+									s->outdated = 1;
+									s->t_last.tv_sec = 0;
+									break;
+								default:
+									break;
+							}
+						}
 					}
 					cleanup_servant_by_pid(pid);
 				}

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -62,6 +62,9 @@
 /* exit status for pcmk-servant */
 #define EXIT_PCMK_SERVANT_GRACEFUL_SHUTDOWN 30
 
+/* exit status for cluster-servant */
+#define EXIT_CLUSTER_DISCONNECT 40
+
 #define HOG_CHAR	0xff
 #define SECTOR_NAME_MAX 63
 


### PR DESCRIPTION
If cluster connection is lost, exit sbd-cluster and let the inquisitor
handle the reconnect by restart.