### PR TITLE
Fix: sbd-common: query rt-budget > 0 otherwise try moving to root-slice

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -33,6 +33,8 @@ int	start_mode = 0;
 char*	pidfile = NULL;
 bool do_flush = true;
 char timeout_sysrq_char = 'b';
+bool move_to_root_cgroup = true;
+bool enforce_moving_to_root_cgroup = false;
 
 int parse_device_line(const char *line);
 
@@ -963,6 +965,19 @@ int main(int argc, char **argv, char **envp)
         value = getenv("SBD_TIMEOUT_ACTION");
         if(value) {
             timeout_action = strdup(value);
+        }
+
+        value = getenv("SBD_MOVE_TO_ROOT_CGROUP");
+        if(value) {
+            move_to_root_cgroup = crm_is_true(value);
+
+            if (move_to_root_cgroup) {
+               enforce_moving_to_root_cgroup = true;
+            } else {
+                if (strcmp(value, "auto") == 0) {
+                    move_to_root_cgroup = true;
+                }
+            }
         }
 
 	while ((c = getopt(argc, argv, "czC:DPRTWZhvw:d:n:p:1:2:3:4:5:t:I:F:S:s:r:")) != -1) {

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -159,6 +159,8 @@ extern bool watchdogdev_is_default;
 extern char*  local_uname;
 extern bool do_flush;
 extern char timeout_sysrq_char;
+extern bool move_to_root_cgroup;
+extern bool enforce_moving_to_root_cgroup;
 
 /* Global, non-tunable variables: */
 extern int  sector_size;

--- a/src/sbd.sysconfig
+++ b/src/sbd.sysconfig
@@ -91,6 +91,20 @@ SBD_WATCHDOG_TIMEOUT=5
 #
 SBD_TIMEOUT_ACTION=flush,reboot
 
+## Type: yesno / auto
+## Default: auto
+#
+# If CPUAccounting is enabled default is not to assign any RT-budget
+# to the system.slice which prevents sbd from running RR-scheduled.
+#
+# One way to escape that issue is to move sbd-processes from the
+# slice they were originally started to root-slice.
+# Of course starting sbd in a certain slice might be intentional.
+# Thus in auto-mode sbd will check if the slice has RT-budget assigned.
+# If that is the case sbd will stay in that slice while it will
+# be moved to root-slice otherwise.
+SBD_MOVE_TO_ROOT_CGROUP=auto
+
 ## Type: string
 ## Default: ""
 #


### PR DESCRIPTION
```
## Type: yesno / auto
## Default: auto
#
# If CPUAccounting is enabled default is not to assign any RT-budget
# to the system.slice which prevents sbd from running RR-scheduled.
#
# One way to escape that issue is to move sbd-processes from the
# slice they were originally started to root-slice.
# Of course starting sbd in a certain slice might be intentional.
# Thus in auto-mode sbd will check if the slice has RT-budget assigned.
# If that is the case sbd will stay in that slice while it will
# be moved to root-slice otherwise.
SBD_MOVE_TO_ROOT_CGROUP=auto
```

Possible additions would be adding a way to define the name of the
slice to switch to instead of root-slice.
In auto-mode it might be interesting as well to define a minimum rt-budget
that prevents switching to root-slice (atm it is anything > 0).