### PR TITLE
Fix the problem that kdump can not get due to the influence of watchdog

### DIFF
--- a/src/sbd-common.c
+++ b/src/sbd-common.c
@@ -1100,6 +1100,9 @@ notify_parent(void)
         /* Our parent died unexpectedly. Triggering
          * self-fence. */
         cl_log(LOG_WARNING, "Our parent is dead.");
+	if (timeout_sysrq_char == 'c') {
+		watchdog_init();
+	}
         do_timeout_action();
     }
 

--- a/src/sbd-md.c
+++ b/src/sbd-md.c
@@ -1139,6 +1139,9 @@ int servant_md(const char *diskname, int mode, const void* argp)
 		if (ppid == 1) {
 			/* Our parent died unexpectedly. Triggering
 			 * self-fence. */
+			if (timeout_sysrq_char == 'c') {
+				watchdog_init();
+			}
 			do_timeout_action();
 		}
 


### PR DESCRIPTION
I am currently checking the operation of "SBD_TIMEOUT_ACTION=flush,crashdump" in version 1.4.0.

In the confirmation, when "sbd: inquisitor" was "SIGKILL", I found a problem that the hardware watchdog is executed after the second kernel migration and kdump can not be acquired.

I think that the problem is that kdump starts running without closing the watchdog device used by 'sbd: inquisitor'.

I made a code to reopen the device to stop / dev / watchdog on the watcher when 'sbd: inquisitor' died, but is this correct?