### PR TITLE
Update build/test for more CI-friendliness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,6 @@ sbd.sh
 *.rpm
 *.tar.*
 !.copr/Makefile
-
+sbd-*/
+.deps
+test-driver

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
 env:
     global:
         - PACKAGE=sbd
-        - BUILD_OS_TYPE=fedora BUILD_OS_DIST= BUILD_OS_VERSION=29
+        - BUILD_OS_TYPE=fedora BUILD_OS_DIST= BUILD_OS_VERSION=30
 
 matrix:
     exclude:
@@ -21,11 +21,11 @@ matrix:
         - os:  linux
           env: OS_ARCH=x86_64 OS_TYPE=centos OS_MOCK=epel OS_DIST=centos OS_VERSION=6
         - os:  linux
-          env: OS_ARCH=x86_64 OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=28
-        - os:  linux
           env: OS_ARCH=x86_64 OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=29
+        - os:  linux
+          env: OS_ARCH=x86_64 OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=30
         - os:  linux-ppc64le
-          env: OS_ARCH=ppc64le OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=29
+          env: OS_ARCH=ppc64le OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=30
 
 services:
   - docker
@@ -45,5 +45,3 @@ addons:
   apt:
     packages:
         - rpm
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,17 @@ services:
 install: true
 
 script:
-  - make -f Makefile.am spec export PACKAGE=${PACKAGE}
+  - make -f Makefile.am srpm PACKAGE=${PACKAGE}
   - docker pull ${BUILD_OS_TYPE}:${BUILD_OS_DIST}${BUILD_OS_VERSION}
-  - docker run --privileged -v ${PWD}:/rpms ${BUILD_OS_TYPE}:${BUILD_OS_DIST}${BUILD_OS_VERSION} /bin/bash -c "dnf install -y mock dnf-utils && mock -r ${OS_MOCK}-${OS_VERSION}-${OS_ARCH} --resultdir=/rpms --no-bootstrap-chroot --old-chroot --disable-plugin=yum_cache --disable-plugin=selinux --buildsrpm --spec /rpms/${PACKAGE}.spec --sources /rpms && mock --no-clean -r ${OS_MOCK}-${OS_VERSION}-${OS_ARCH} --resultdir=/rpms --disable-plugin=yum_cache --disable-plugin=selinux --no-bootstrap-chroot --old-chroot /rpms/sbd*.src.rpm"
+  - docker run --privileged -v ${PWD}:/rpms ${BUILD_OS_TYPE}:${BUILD_OS_DIST}${BUILD_OS_VERSION} /bin/bash -c "dnf install -y mock dnf-utils && mock --no-clean -r ${OS_MOCK}-${OS_VERSION}-${OS_ARCH} --resultdir=/rpms --disable-plugin=yum_cache --disable-plugin=selinux --no-bootstrap-chroot --old-chroot /rpms/sbd*.src.rpm"
   - ls ${PWD}/${PACKAGE}*.${OS_ARCH}.rpm
   - docker pull ${OS_TYPE}:${OS_DIST}${OS_VERSION}
   - docker run --privileged -v ${PWD}:/rpms -v ${PWD}/tests:/tests ${OS_TYPE}:${OS_DIST}${OS_VERSION} /bin/bash -c "yum install -y device-mapper /rpms/${PACKAGE}*.${OS_ARCH}.rpm && /tests/regressions.sh && touch /rpms/regressions.sh.SUCCESS"
   - ls ${PWD}/regressions.sh.SUCCESS
+
+addons:
+  apt:
+    packages:
+        - rpm
+
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,16 +1,23 @@
 SUBDIRS = src agent man
 
 # .gz because github doesn't support .xz yet :-(
-
-TAG		?= $(shell git log --pretty="format:%H" -n 1)
+# this is modified
+#
+TAG		?= $(shell git log --pretty="format:%H" -n 1 || sed -n -e "s/%global commit //p" sbd.spec)$(shell test -n "$$(git status -s)" && echo -n "-mod")
 distdir		 = $(PACKAGE)-$(TAG)
 TARFILE		 = $(distdir).tar.gz
 DIST_ARCHIVES	 = $(TARFILE)
+KEEP_EXISTING_TAR = no
+INJECT_GIT_COMMIT = yes
+DISTCLEANFILES   = sbd-* sbd-*/
+CLEANFILES       = *.rpm *.tar.* sbd-*
 
 RPM_ROOT	= $(shell pwd)
 RPM_OPTS	= --define "_sourcedir $(RPM_ROOT)" 	\
 		  --define "_specdir   $(RPM_ROOT)" 	\
-		  --define "_srcrpmdir $(RPM_ROOT)"
+		  --define "_srcrpmdir $(RPM_ROOT)"     \
+		  --define "_builddir  $(RPM_ROOT)"     \
+		  --define "_rpmdir    $(RPM_ROOT)"
 
 MOCK_TARGET     ?= rhel-7.1-candidate-x86_64
 MOCK_OPTIONS	?= --resultdir=$(RPM_ROOT)/mock --no-cleanup-after
@@ -19,30 +26,51 @@ BUILD_COUNTER	?= build.counter
 LAST_COUNT      = $(shell test ! -e $(BUILD_COUNTER) && echo 0; test -e $(BUILD_COUNTER) && cat $(BUILD_COUNTER))
 COUNT           = $(shell expr 1 + $(LAST_COUNT))
 
+TESTS           = tests/regressions.sh
+export SBD_BINARY := src/sbd
+EXTRA_DIST      = sbd.spec tests/regressions.sh
+
 export:
 	rm -f $(PACKAGE)-HEAD.tar.*
+	if test "$(KEEP_EXISTING_TAR)" != "yes"; then \
+	    rm -f $(TARFILE); \
+	fi;
+	! (git status -s | grep "??" && echo "untracked files present in git-repo" )
 	if [ -f $(TARFILE) ]; then						\
 	    echo `date`: Using existing tarball: $(TARFILE);			\
 	else									\
-	    rm -f $(PACKAGE).tar.*;						\
-	    git archive --prefix=$(distdir)/ $(TAG) | gzip > $(TARFILE);	\
+	    rm -f $(PACKAGE).tar.*;                                             \
+	    (git archive --prefix=$(distdir)/ $(shell echo $(TAG)|cut -f1 -d-) || tar -c --transform="s,^,$(distdir)/," --exclude="*.tar.*" --exclude="$(distdir)" --exclude="*.o" --exclude="*.8" --exclude="config.*" --exclude="Makefile" --exclude="Makefile.in" --exclude="stamp-*" --exclude="*.service" --exclude="sbd" --exclude="*.m4" --exclude="*.cache" --exclude="configure" --exclude="*.list" --exclude="depcomp" --exclude="install-sh" --exclude="missing" --exclude="compile" --exclude="sbd.sh" --exclude="~" --exclude="*.swp" --exclude="*.patch" --exclude="*.diff" --exclude="*.orig" --exclude="*.rej" --exclude="*.rpm" --exclude=".deps" --exclude="test-driver" *) | gzip > $(TARFILE);	\
+	    if test -n "$$(git status -s)" || test "$(INJECT_GIT_COMMIT)" = "yes"; then \
+		if test -n "$$(git status -s)"; then git diff HEAD > uncommitted.diff; fi; \
+		rm -rf $(distdir); tar -xzf $(TARFILE); rm $(TARFILE); \
+		cd $(distdir); \
+		if test -n "$$(git status -s)"; then patch -p1 -i ../uncommitted.diff; fi; \
+		cd ..; \
+		sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(distdir)/$(PACKAGE).spec; \
+		tar -czf $(TARFILE) $(distdir); rm -rf $(distdir); \
+		rm -f uncommitted.diff; \
+	    fi; \
 	    echo `date`: Rebuilt $(TARFILE);					\
 	fi
 
-#replace commit id in sbd.spce
+#replace commit id in sbd.spec
 spec:
 	rm -f *.src.rpm
-	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(PACKAGE).spec
+	rm -rf $(distdir)
+	mkdir $(distdir)
+	cp $(PACKAGE).spec $(distdir)
+	sed -i 's/global\ commit.*/global\ commit\ $(TAG)/' $(distdir)/$(PACKAGE).spec
 
-srpm:	spec export
+srpm:	export spec
 	if [ -e $(BUILD_COUNTER) ]; then							\
-		sed -i 's/global\ buildnum.*/global\ buildnum\ $(COUNT)/' $(PACKAGE).spec;	\
+		sed -i 's/global\ buildnum.*/global\ buildnum\ $(COUNT)/' $(distdir)/$(PACKAGE).spec;	\
 		echo $(COUNT) > $(BUILD_COUNTER);					\
 	fi
-	rpmbuild $(RPM_OPTS) -bs $(PACKAGE).spec
+	rpmbuild $(RPM_OPTS) -bs $(distdir)/$(PACKAGE).spec
 
-rpm:	spec export
-	rpmbuild $(RPM_OPTS) -ba $(PACKAGE).spec
+rpm:	export spec
+	rpmbuild $(RPM_OPTS) -ba $(distdir)/$(PACKAGE).spec
 
 mock:   srpm
 	-rm -rf $(RPM_ROOT)/mock
@@ -53,3 +81,4 @@ beekhof: mock
 	cluster-helper -- 'rm -f sbd-*.x86_64.rpm'
 	cluster-helper --copy $(RPM_ROOT)/mock/sbd-*.x86_64.rpm {}: 
 	cluster-helper -- yum install -y sbd-*.x86_64.rpm
+

--- a/configure.ac
+++ b/configure.ac
@@ -51,11 +51,13 @@ elif test $HAVE_pacemaker = 1; then
         AC_MSG_NOTICE(No library 'cmap' found)
     else
         CPPFLAGS="$CPPFLAGS $cmap_CFLAGS"
+        LIBS="$LIBS $cmap_LIBS"
     fi
     if test $HAVE_votequorum = 0; then
         AC_MSG_NOTICE(No library 'votequorum' found)
     else
         CPPFLAGS="$CPPFLAGS $votequorum_CFLAGS"
+        LIBS="$LIBS $votequorum_LIBS"
     fi
 fi
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,6 +1,6 @@
-man_MANS	= sbd.8
+dist_man_MANS	= sbd.8
 
-EXTRA_DIST	= $(man_MANS)
+EXTRA_DIST	= sbd.8.pod
 
 sbd.8:	sbd.8.pod
 	@POD2MAN@ -s 8 -c "STONITH Block Device" -r "SBD" -n "SBD" $< $@

--- a/sbd.spec
+++ b/sbd.spec
@@ -15,8 +15,9 @@
 
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
-%global commit 2d595fdde4f62278b96db1b7fb79aae5e990bb0b
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit 5705703da3db01bb4c34fd73ae33f24b43a16b78-mod
+%global shortcommit %(echo %{commit}|cut -c1-8)
+%global modified %(echo %{commit}-|cut -f2 -d-)
 %global github_owner beekhof
 %global buildnum 1
 
@@ -25,7 +26,7 @@ Summary:        Storage-based death
 License:        GPLv2+
 Group:          System Environment/Daemons
 Version:        1.4.0
-Release:        0.%{buildnum}.%{shortcommit}.git%{?dist}
+Release:        99.%{buildnum}.%{shortcommit}.%{modified}git%{?dist}
 Url:            https://github.com/%{github_owner}/%{name}
 Source0:        https://github.com/%{github_owner}/%{name}/archive/%{commit}/%{name}-%{commit}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/sbd.spec
+++ b/sbd.spec
@@ -36,7 +36,11 @@ BuildRequires:  libuuid-devel
 BuildRequires:  glib2-devel
 BuildRequires:  libaio-devel
 BuildRequires:  corosynclib-devel
+%if 0%{?suse_version}
+BuildRequires:  libpacemaker-devel
+%else
 BuildRequires:  pacemaker-libs-devel
+%endif
 BuildRequires:  libtool
 BuildRequires:  libuuid-devel
 BuildRequires:  libxml2-devel

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@ AM_CPPFLAGS =  -I$(includedir)/pacemaker  \
 
 sbin_PROGRAMS = sbd
 
-sbd_SOURCES = sbd-common.c sbd-inquisitor.c sbd-pacemaker.c sbd-cluster.c setproctitle.c
+sbd_SOURCES = sbd-common.c sbd-inquisitor.c sbd-pacemaker.c sbd-cluster.c setproctitle.c sbd.h sbd.sysconfig
 
 if SUPPORT_SHARED_DISK
 sbd_SOURCES += sbd-md.c

--- a/tests/regressions.sh
+++ b/tests/regressions.sh
@@ -27,6 +27,12 @@
 # - How to test watch mode?
 # - Can the unit/service file be tested? or at least the wrapper?
 
+: ${SBD_BINARY:="/usr/sbin/sbd"}
+
+sbd() {
+	${SBD_BINARY} $*
+}
+
 sbd_setup() {
 	trap sbd_teardown EXIT
 	for N in $(seq 3) ; do


### PR DESCRIPTION
- Update .gitignore
- Make tar generation smarter
    - check for git underneath
    - check for git modifications
    - build proper tar without git
- Versioned sbd.spec goes to subdir
- Specify additional source-files for distcheck to find
- Add tests/regressions.sh to check-target
- Add env SBD_BINARY to use custom binary in regression.sh
- Use srpm-target directly from ubuntu for travis 