### PR TITLE
avoid deprecated naems for g_main-loop-functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
           env: OS_ARCH=x86_64 OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=29
         - os:  linux
           env: OS_ARCH=x86_64 OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=30
+        - os:  linux
+          env: OS_ARCH=x86_64 OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=rawhide
         - os:  linux-ppc64le
           env: OS_ARCH=ppc64le OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=30
 
@@ -35,10 +37,10 @@ install: true
 script:
   - make -f Makefile.am srpm PACKAGE=${PACKAGE}
   - docker pull ${BUILD_OS_TYPE}:${BUILD_OS_DIST}${BUILD_OS_VERSION}
-  - docker run --privileged -v ${PWD}:/rpms ${BUILD_OS_TYPE}:${BUILD_OS_DIST}${BUILD_OS_VERSION} /bin/bash -c "dnf install -y mock dnf-utils && mock --no-clean -r ${OS_MOCK}-${OS_VERSION}-${OS_ARCH} --resultdir=/rpms --disable-plugin=yum_cache --disable-plugin=selinux --no-bootstrap-chroot --old-chroot /rpms/sbd*.src.rpm"
+  - docker run --privileged -v ${PWD}:/rpms ${BUILD_OS_TYPE}:${BUILD_OS_DIST}${BUILD_OS_VERSION} /bin/bash -c "dnf install -y mock dnf-utils && if test $OS_VERSION = rawhide; then sed -i /etc/mock/${OS_MOCK}-${OS_VERSION}-${OS_ARCH}.cfg -e s/gpgcheck.*/gpgcheck=0/g; fi && mock --no-clean -r ${OS_MOCK}-${OS_VERSION}-${OS_ARCH} --resultdir=/rpms --disable-plugin=yum_cache --disable-plugin=selinux --no-bootstrap-chroot --old-chroot /rpms/sbd*.src.rpm"
   - ls ${PWD}/${PACKAGE}*.${OS_ARCH}.rpm
   - docker pull ${OS_TYPE}:${OS_DIST}${OS_VERSION}
-  - docker run --privileged -v ${PWD}:/rpms -v ${PWD}/tests:/tests ${OS_TYPE}:${OS_DIST}${OS_VERSION} /bin/bash -c "yum install -y device-mapper /rpms/${PACKAGE}*.${OS_ARCH}.rpm && /tests/regressions.sh && touch /rpms/regressions.sh.SUCCESS"
+  - docker run --privileged -v ${PWD}:/rpms -v ${PWD}/tests:/tests ${OS_TYPE}:${OS_DIST}${OS_VERSION} /bin/bash -c "if test $OS_VERSION = rawhide; then yum update -y --nogpgcheck; fi && yum install -y device-mapper /rpms/${PACKAGE}*.${OS_ARCH}.rpm && /tests/regressions.sh && touch /rpms/regressions.sh.SUCCESS"
   - ls ${PWD}/regressions.sh.SUCCESS
 
 addons:

--- a/src/sbd-cluster.c
+++ b/src/sbd-cluster.c
@@ -588,14 +588,14 @@ servant_cluster(const char *diskname, int mode, const void* argp)
     /* stonith_our_uname = cluster.uname; */
     /* stonith_our_uuid = cluster.uuid; */
 
-    mainloop = g_main_new(FALSE);
+    mainloop = g_main_loop_new(NULL, FALSE);
     notify_timer = g_timeout_add(timeout_loop * 1000, notify_timer_cb, NULL);
 
     mainloop_add_signal(SIGTERM, cluster_shutdown);
     mainloop_add_signal(SIGINT, cluster_shutdown);
     
-    g_main_run(mainloop);
-    g_main_destroy(mainloop);
+    g_main_loop_run(mainloop);
+    g_main_loop_unref(mainloop);
     
     clean_up(0);
     return 0;                   /* never reached */

--- a/src/sbd-pacemaker.c
+++ b/src/sbd-pacemaker.c
@@ -562,14 +562,14 @@ servant_pcmk(const char *diskname, int mode, const void* argp)
 		}
 	}
 
-	mainloop = g_main_new(FALSE);
+	mainloop = g_main_loop_new(NULL, FALSE);
 
 	mainloop_add_signal(SIGTERM, mon_shutdown);
 	mainloop_add_signal(SIGINT, mon_shutdown);
 	timer_id_notify = g_timeout_add(timeout_loop * 1000, mon_timer_notify, NULL);
 
-	g_main_run(mainloop);
-	g_main_destroy(mainloop);
+	g_main_loop_run(mainloop);
+	g_main_loop_unref(mainloop);
 
 	clean_up(0);
 	return 0;                   /* never reached */


### PR DESCRIPTION
and add fedora-rawhide that was as of now the first fedora to build-fail because of using them.
and unfortunately fedora-rawhide seems to have issues gpg-keys
doing an update without gpg-key-checking and removing the gpg-check from mock-config for rawhide seems to solve the issue for now and should be removed once the issue is gone otherwise.