### PR TITLE
travis: add aarch64 s390x epel-8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,52 @@
+dist: bionic
 sudo: required
 language: c
 
 os:
     - linux
-    - linux-ppc64le
+
+arch:
+    - amd64
+    - ppc64le
+    - s390x
+    - arm64
 
 env:
     global:
         - PACKAGE=sbd
-        - BUILD_OS_TYPE=fedora BUILD_OS_DIST= BUILD_OS_VERSION=29
+        # appealing idea to go with centos 8 as build-host but unfortunately that isn't available for all platforms
+        # and the docker-image isn't there for anything else but x86_64
+        # - BUILD_OS_TYPE="centos:" BUILD_OS_DIST=centos BUILD_OS_VERSION=8
+        # - BUILD_OS_PREPARE="yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && yum install -y mock yum-utils &&"
+        - BUILD_OS_TYPE="fedora:" BUILD_OS_DIST= BUILD_OS_VERSION=30
+        - BUILD_OS_PREPARE="dnf install -y mock dnf-utils findutils patch &&"
 
 matrix:
     exclude:
-        - os:  linux
-        - os:  linux-ppc64le
+        - arch: amd64
+        - arch: ppc64le
+        - arch: s390x
+        - arch: arm64
 
     include:
-        - os:  linux
-          env: OS_ARCH=x86_64 OS_TYPE=centos OS_MOCK=epel OS_DIST=centos OS_VERSION=7
-        - os:  linux
-          env: OS_ARCH=x86_64 OS_TYPE=centos OS_MOCK=epel OS_DIST=centos OS_VERSION=6
-        - os:  linux
-          env: OS_ARCH=x86_64 OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=29
-        - os:  linux
-          env: OS_ARCH=x86_64 OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=30
-        - os:  linux
-          env: OS_ARCH=x86_64 OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=rawhide
-        - os:  linux-ppc64le
-          env: OS_ARCH=ppc64le OS_TYPE=fedora OS_MOCK=fedora OS_DIST= OS_VERSION=30
+        - arch: amd64
+          env: OS_ARCH=x86_64 OS_TYPE="centos:" OS_MOCK=epel OS_DIST=centos OS_VERSION=7 OS_INSTALL="yum install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+        - arch: amd64
+          env: OS_ARCH=x86_64 OS_TYPE="centos:" OS_MOCK=epel OS_DIST=centos OS_VERSION=6 OS_INSTALL="yum install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+        - arch: amd64
+          env: OS_ARCH=x86_64 OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=30 OS_INSTALL="dnf install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+        - arch: amd64
+          env: OS_ARCH=x86_64 OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=rawhide OS_INSTALL="dnf install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+        - arch: ppc64le
+          env: OS_ARCH=ppc64le OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=30 OS_INSTALL="dnf install -y" DOCKER_OPTS="--cap-add=sys_admin" TEST_ENV="SBD_USE_DM=no" MOCK_OPTS="--config-opts=internal_dev_setup=False"
+        - arch: s390x
+          env: OS_ARCH=s390x OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=30 OS_INSTALL="dnf install -y" DOCKER_OPTS="--cap-add=sys_admin" TEST_ENV="SBD_USE_DM=no" MOCK_OPTS="--config-opts=internal_dev_setup=False"
+        - arch: arm64
+          env: OS_ARCH=aarch64 OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=30 OS_INSTALL="dnf install -y" DOCKER_OPTS="--cap-add=sys_admin" TEST_ENV="SBD_USE_DM=no" MOCK_OPTS="--config-opts=internal_dev_setup=False"
+        - arch: amd64
+          env: OS_ARCH=x86_64 OS_TYPE="opensuse/" OS_MOCK=opensuse-leap OS_DIST="leap:" OS_VERSION=15.1 OS_INSTALL="zypper --no-gpg-checks --non-interactive install" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+        - arch: amd64
+          env: OS_ARCH=x86_64 OS_TYPE="opensuse/" OS_MOCK=opensuse OS_DIST= OS_VERSION=tumbleweed OS_INSTALL="zypper --no-gpg-checks --non-interactive install" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
 
 services:
   - docker
@@ -35,15 +54,17 @@ services:
 install: true
 
 script:
+  - BUILD_SUCCESS=false
   - make -f Makefile.am srpm PACKAGE=${PACKAGE}
-  - docker pull ${BUILD_OS_TYPE}:${BUILD_OS_DIST}${BUILD_OS_VERSION}
-  - docker run --privileged -v ${PWD}:/rpms ${BUILD_OS_TYPE}:${BUILD_OS_DIST}${BUILD_OS_VERSION} /bin/bash -c "dnf install -y mock dnf-utils && if test $OS_VERSION = rawhide; then sed -i /etc/mock/${OS_MOCK}-${OS_VERSION}-${OS_ARCH}.cfg -e s/gpgcheck.*/gpgcheck=0/g; fi && mock --no-clean -r ${OS_MOCK}-${OS_VERSION}-${OS_ARCH} --resultdir=/rpms --disable-plugin=yum_cache --disable-plugin=selinux --no-bootstrap-chroot --old-chroot /rpms/sbd*.src.rpm"
-  - ls ${PWD}/${PACKAGE}*.${OS_ARCH}.rpm
-  - docker pull ${OS_TYPE}:${OS_DIST}${OS_VERSION}
-  - docker run --privileged -v ${PWD}:/rpms ${OS_TYPE}:${OS_DIST}${OS_VERSION} /bin/bash -c "if test $OS_VERSION = rawhide; then yum update -y --nogpgcheck; fi && yum install -y device-mapper /rpms/${PACKAGE}*.${OS_ARCH}.rpm && /usr/share/sbd/regressions.sh && touch /rpms/regressions.sh.SUCCESS"
+  - docker pull ${BUILD_OS_TYPE}${BUILD_OS_DIST}${BUILD_OS_VERSION}
+  - docker run --cap-add=sys_admin -v ${PWD}:/rpms -v /proc:/var/lib/mock/${OS_MOCK}-${OS_VERSION}-${OS_ARCH}/root/proc -v ${PWD}:/rpms -v /sys:/var/lib/mock/${OS_MOCK}-${OS_VERSION}-${OS_ARCH}/root/sys ${BUILD_OS_TYPE}${BUILD_OS_DIST}${BUILD_OS_VERSION} /bin/bash -c "${BUILD_OS_PREPARE} if test $OS_VERSION = rawhide; then sed -i /etc/mock/${OS_MOCK}-${OS_VERSION}-${OS_ARCH}.cfg -e s/gpgcheck.*/gpgcheck=0/g; fi && rpm -ql mock|grep "/mounts.py\$"|xargs -n1 sed -e "/USE_NSPAWN/d" -e "/self.mountall_essential/d" -i && mock --no-clean -r ${OS_MOCK}-${OS_VERSION}-${OS_ARCH} --resultdir=/rpms ${MOCK_OPTS} --disable-plugin=root_cache --disable-plugin=tmpfs --disable-plugin=yum_cache --disable-plugin=selinux --no-bootstrap-chroot --old-chroot /rpms/sbd*.src.rpm"
+  - ls ${PWD}/${PACKAGE}*.${OS_ARCH}.rpm && BUILD_SUCCESS=true
+  - ${BUILD_SUCCESS} && docker pull ${OS_TYPE}${OS_DIST}${OS_VERSION}
+  - ${BUILD_SUCCESS} && docker run ${DOCKER_OPTS} -v ${PWD}:/rpms ${OS_TYPE}${OS_DIST}${OS_VERSION} /bin/bash -c "if test $OS_VERSION = rawhide; then dnf update -y --nogpgcheck; fi && ${OS_INSTALL} device-mapper /rpms/${PACKAGE}*.${OS_ARCH}.rpm && ${TEST_ENV} /usr/share/sbd/regressions.sh && touch /rpms/regressions.sh.SUCCESS"
   - ls ${PWD}/regressions.sh.SUCCESS
 
 addons:
   apt:
     packages:
         - rpm
+

--- a/tests/regressions.sh
+++ b/tests/regressions.sh
@@ -298,7 +298,7 @@ test_timeout_action1() {
 	SBD_TIMEOUT_ACTION=off sbd -d ${D[1]} -w /dev/null -n test-1 watch
 	sleep 2
 	sbd_wipe_disk ${D[1]}
-	sleep 10
+	sleep 15
 	_in_log "sysrq-trigger ('o')"
 	_in_log "reboot (poweroff)"
 }
@@ -310,7 +310,7 @@ test_timeout_action2() {
 	SBD_TIMEOUT_ACTION=crashdump sbd -d ${D[1]} -w /dev/null -n test-1 watch
 	sleep 2
 	sbd_wipe_disk ${D[1]}
-	sleep 10
+	sleep 15
 	_in_log "sysrq-trigger ('c')"
 }
 


### PR DESCRIPTION
This adds both additional architectures (aarch64 & s390x) and Suse build-targets to the travis-CI.

While adding the Suse build-targets just introduced a bit of uglyness due to longer lines and
less readability due to the different naming conventions for mock-build-targets and containers
the additional architectures were a real pain due to them running in LXD containers.
Problem is that the containers inside thes LXD containers can't be run privileged and not
even sys_admin-capabilities do arrive properly inside the container.

For testing the packages this can be mitigated instructing the new testbed-preload-library
to remove the requirement for device-mapper (buying us a slightly inferior test but well ...).

The real pain was mock that had to be instructed not to do a couple of things like nspawn-containers,
bindmounts and stuff. Most things could be disabled via available config. What stayed and
had to be patched out for the first was mounting of /proc and /sys.
That is all not very beautiful but it seems to be working and more effort may be moot to a
certain extent as how the additional architectures are made available via LXD is subject to
change anyway as told by travis. Enabling the nesting-capability for the containers would
e.g. sound interesting but so far there doesn't seem to be a configuration option.
Of course we won't ever have the LXD containers privileged to an extent that we could
have device-mapper and loopback-mounts inside as long as the kernel doesn't provide
the proper namespaces and running in the same namespace as the other users seems
critical of course. 

Dealing with the issue makes probably sense as travis seems to intend moving the AMD64
machines to LXD containers as well.
ppc64le btw. is basically functional but is failing quite often due to slow repo access. Don't
know if it has slower network-access than the other architectures or if it is just slow or
overcommitted.

Piggybacked there comes a small relaxation for timeouts of 2 tests that turned out to
be necessary to cope better with loaded test infrastructure. (I know at least partly I
was the reason for this overload amending the PR again and again till I got it to work ;-) )