### PR TITLE
Doc: add environment section to man-page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ sbd.sh
 *.orig
 *.rej
 *.rpm
+*.pod
 *.tar.*
 !.copr/Makefile
 sbd-*/

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,8 +9,8 @@ TARFILE		 = $(distdir).tar.gz
 DIST_ARCHIVES	 = $(TARFILE)
 KEEP_EXISTING_TAR = no
 INJECT_GIT_COMMIT = yes
-DISTCLEANFILES   = sbd-* sbd-*/
 CLEANFILES       = *.rpm *.tar.* sbd-*
+DISTCLEANFILES   = sbd-* sbd-*/
 
 RPM_ROOT	= $(shell pwd)
 RPM_OPTS	= --define "_sourcedir $(RPM_ROOT)" 	\
@@ -31,7 +31,7 @@ export SBD_BINARY := src/sbd
 export SBD_PRELOAD := tests/.libs/libsbdtestbed.so
 export SBD_USE_DM := no
 
-EXTRA_DIST      = sbd.spec tests/regressions.sh
+EXTRA_DIST      = sbd.spec tests/regressions.sh man/sbd.8.pod.in
 
 export:
 	rm -f $(PACKAGE)-HEAD.tar.*
@@ -43,7 +43,7 @@ export:
 	    echo `date`: Using existing tarball: $(TARFILE);			\
 	else									\
 	    rm -f $(PACKAGE).tar.*;                                             \
-	    (git archive --prefix=$(distdir)/ $(shell echo $(TAG)|cut -f1 -d-) || tar -c --transform="s,^,$(distdir)/," --exclude="*.tar.*" --exclude="$(distdir)" --exclude="*.o" --exclude="*.8" --exclude="config.*" --exclude="libtool" --exclusive="ltmain.sh*" --exclude="Makefile" --exclude="Makefile.in" --exclude="stamp-*" --exclude="*.service" --exclude="sbd" --exclude="*.m4" --exclude="*.cache" --exclude="configure" --exclude="*.list" --exclude="depcomp" --exclude="install-sh" --exclude="missing" --exclude="compile" --exclude="sbd.sh" --exclude="~" --exclude="*.swp" --exclude="*.patch" --exclude="*.diff" --exclude="*.orig" --exclude="*.rej" --exclude="*.rpm" --exclude=".deps" --exclude="test-driver" *) | gzip > $(TARFILE);	\
+	    (git archive --prefix=$(distdir)/ $(shell echo $(TAG)|cut -f1 -d-) || tar -c --transform="s,^,$(distdir)/," --exclude="*.tar.*" --exclude="$(distdir)" --exclude="*.o" --exclude="*.8" --exclude="config.*" --exclude="libtool" --exclude="ltmain.sh*" --exclude="Makefile" --exclude="Makefile.in" --exclude="stamp-*" --exclude="*.service" --exclude="sbd" --exclude="*.m4" --exclude="*.cache" --exclude="configure" --exclude="*.list" --exclude="depcomp" --exclude="install-sh" --exclude="missing" --exclude="compile" --exclude="sbd.sh" --exclude="~" --exclude="*.swp" --exclude="*.patch" --exclude="*.diff" --exclude="*.orig" --exclude="*.rej" --exclude="*.rpm" --exclude="*.pod" --exclude=".deps" --exclude="test-driver" *) | gzip > $(TARFILE);	\
 	    if test -n "$$(git status -s)" || test "$(INJECT_GIT_COMMIT)" = "yes"; then \
 		if test -n "$$(git status -s)"; then git diff HEAD --name-only|grep -v "^\."|xargs -n1 git diff HEAD > uncommitted.diff; fi; \
 		rm -rf $(distdir); tar -xzf $(TARFILE); rm $(TARFILE); \

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ A highly reliable fencing or Shoot-the-other-node-in-the-head (STONITH) mechanis
 The component works with Pacemaker clusters, and is currently known to
 compile and function on Pacemaker 1.1.7+ and corosync 1.4.x or 2.3.x.
 
-Please see https://github.com/l-mb/sbd/blob/master/man/sbd.8.pod for the full documentation.
+Please see https://github.com/clusterlabs/sbd/blob/master/man/sbd.8.pod.in &
+https://github.com/clusterlabs/sbd/blob/master/src/sbd.sysconfig for the full documentation.
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,6 +1,12 @@
 dist_man_MANS	= sbd.8
 
-EXTRA_DIST	= sbd.8.pod
+DISTCLEANFILES = sbd.8.pod sbd.8 sbd.sysconfig.pod
+
+sbd.sysconfig.pod: ../src/sbd.sysconfig
+	sed -r -n -e "s/^## Type: (.*)/Allows C<\1>/;t type;s/^## Default: (.*)/ defaulting to C<\1>/;t default;s/^#*(.*)=.*/=item B<\1>\n/;t variable;s/^#*//;s/^ *//;H;d;:type;h;d;:default;H;x;s/\n//;x;d;:variable;G;p" $< > $@
+
+sbd.8.pod: sbd.8.pod.in sbd.sysconfig.pod
+	sed -e "s/@environment_section@//;t insert;p;d;:insert;rsbd.sysconfig.pod" $< > $@
 
 sbd.8:	sbd.8.pod
 	@POD2MAN@ -s 8 -c "STONITH Block Device" -r "SBD" -n "SBD" $< $@

--- a/man/sbd.8.pod.in
+++ b/man/sbd.8.pod.in
@@ -568,9 +568,16 @@ options to pass to the daemon:
 	SBD_PACEMAKER="true"
 
 C<sbd> will fail to start if no C<SBD_DEVICE> is specified. See the
-installed template for more options that can be configured here.
+installed template or section for configuration via environment
+for more options that can be configured here.
 In general configuration done via parameters takes precedence over
 the configuration from the configuration file.
+
+=head2 Configuration via environment
+
+=over
+@environment_section@
+=back
 
 =head2 Testing the sbd installation
 

--- a/src/sbd.sysconfig
+++ b/src/sbd.sysconfig
@@ -14,7 +14,7 @@
 #
 SBD_PACEMAKER=yes
 
-## Type: list(always,clean)
+## Type: always / clean
 ## Default: always
 #
 # Specify the start mode for sbd. Setting this to "clean" will only
@@ -103,6 +103,7 @@ SBD_TIMEOUT_ACTION=flush,reboot
 # Thus in auto-mode sbd will check if the slice has RT-budget assigned.
 # If that is the case sbd will stay in that slice while it will
 # be moved to root-slice otherwise.
+#
 SBD_MOVE_TO_ROOT_CGROUP=auto
 
 ## Type: string


### PR DESCRIPTION
Environment section is auto-generated from sbd.sysconfig.

Originally intended to have this done by config.status - thus the @...@ an .in extension - but finally went for a simple sed replace.
Intention is to still have documentation for environment-variables even if some high-level-tool (e.g. pcs) overwrites /etc/sysconfig/sbd or config-files are copied around.