### PR TITLE
handle new no_quorum_demote introduced in pacemaker

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,22 @@ AC_CHECK_LIB(cib, cib_apply_patch_event, , missing="yes")
 
 dnl pacemaker-2.0 removed support for corosync 1 cluster layer
 AC_CHECK_DECLS([pcmk_cluster_classic_ais, pcmk_cluster_cman],,,
-	       [#include <pacemaker/crm/cluster.h>])
+               [#include <pacemaker/crm/cluster.h>])
+
+dnl check for additional no-quorum-policies
+dnl AC_TEST_NO_QUORUM_POLICY(POLICY)
+AC_DEFUN([AC_TEST_NO_QUORUM_POLICY],[
+    AC_MSG_CHECKING([whether enum pe_quorum_policy defines value $1])
+    AC_LANG_PUSH([C])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+        [#include <pacemaker/crm/pengine/pe_types.h>],
+        [enum pe_quorum_policy policy = $1; return policy;])],
+            AC_DEFINE_UNQUOTED(m4_toupper(HAVE_ENUM_$1), 1,
+            [Does pe_types.h have $1 value in enum pe_quorum_policy?])
+            AC_MSG_RESULT([yes]), AC_MSG_RESULT([no]))
+    AC_LANG_POP([C])
+])
+AC_TEST_NO_QUORUM_POLICY(no_quorum_demote)
 
 dnl check for new pe-API
 AC_CHECK_FUNCS(pe_new_working_set)

--- a/src/sbd-pacemaker.c
+++ b/src/sbd-pacemaker.c
@@ -321,13 +321,22 @@ compute_status(pe_working_set_t * data_set)
             case no_quorum_freeze:
                 set_servant_health(pcmk_health_transient, LOG_INFO, "Quorum lost: Freeze resources");
                 break;
+#if HAVE_ENUM_NO_QUORUM_DEMOTE
+            case no_quorum_demote:
+                set_servant_health(pcmk_health_transient, LOG_INFO,
+                    "Quorum lost: Demote promotable resources and stop others");
+                break;
+#endif
             case no_quorum_stop:
                 set_servant_health(pcmk_health_transient, LOG_INFO, "Quorum lost: Stop ALL resources");
                 break;
             case no_quorum_ignore:
                 set_servant_health(pcmk_health_transient, LOG_INFO, "Quorum lost: Ignore");
                 break;
-            case no_quorum_suicide:
+            default:
+                /* immediate reboot is the most excessive action we take
+                   use for no_quorum_suicide and everything we don't know yet
+                 */
                 set_servant_health(pcmk_health_unclean, LOG_INFO, "Quorum lost: Self-fence");
                 break;
         }


### PR DESCRIPTION
Pacemaker introduced a new no-quorum-policy no_quorum_demote.

Code up to now would probably not compile against new pacemaker-headers (dependent on
compiler and flags) or static analysis would catch not all enums being handled.
Even worse is with using existing sbd-binaries (or compiled in an environment that doesn't
complain) a loss of quorum would be ignored by sbd possibly leading to split-brain.

Now we test for existence of the new enum value and use it (same as no_quorum_stop).
To be more robust against no-quorum-policies added in the future unknown policies are
now handled as would be done with no_quorum_suicide. This triggers an immediate
suicide in case of quorum-loss and unknown policy which should provide best robustness
against split-brain.