### PR TITLE
Fix: sbd-cluster: match qdevice-sync_timeout against wd-timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,13 @@ matrix:
 
     include:
         - arch: amd64
-          env: OS_ARCH=x86_64 OS_TYPE="centos:" OS_MOCK=epel OS_DIST=centos OS_VERSION=7 OS_INSTALL="yum install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+          env: OS_ARCH=x86_64 OS_TYPE="centos:" OS_MOCK=epel OS_DIST=centos OS_VERSION=7 OS_INSTALL="yum install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=no"
         - arch: amd64
-          env: OS_ARCH=x86_64 OS_TYPE="centos:" OS_MOCK=epel OS_DIST=centos OS_VERSION=6 OS_INSTALL="yum install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+          env: OS_ARCH=x86_64 OS_TYPE="centos:" OS_MOCK=epel OS_DIST=centos OS_VERSION=6 OS_INSTALL="yum install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=no"
         - arch: amd64
-          env: OS_ARCH=x86_64 OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=32 OS_INSTALL="dnf install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+          env: OS_ARCH=x86_64 OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=32 OS_INSTALL="dnf install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=no"
         - arch: amd64
-          env: OS_ARCH=x86_64 OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=rawhide OS_INSTALL="dnf install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+          env: OS_ARCH=x86_64 OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=rawhide OS_INSTALL="dnf install -y" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=no"
         - arch: ppc64le
           env: OS_ARCH=ppc64le OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=32 OS_INSTALL="dnf install --setopt=timeout=300 -y" DOCKER_OPTS="--cap-add=sys_admin" TEST_ENV="SBD_USE_DM=no" MOCK_OPTS="--config-opts=internal_dev_setup=False"
         - arch: s390x
@@ -44,9 +44,9 @@ matrix:
         - arch: arm64
           env: OS_ARCH=aarch64 OS_TYPE="fedora:" OS_MOCK=fedora OS_DIST= OS_VERSION=32 OS_INSTALL="dnf install -y" DOCKER_OPTS="--cap-add=sys_admin" TEST_ENV="SBD_USE_DM=no" MOCK_OPTS="--config-opts=internal_dev_setup=False"
         - arch: amd64
-          env: OS_ARCH=x86_64 OS_TYPE="opensuse/" OS_MOCK=opensuse-leap OS_DIST="leap:" OS_VERSION=15.2 OS_INSTALL="zypper --no-gpg-checks --non-interactive install" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+          env: OS_ARCH=x86_64 OS_TYPE="opensuse/" OS_MOCK=opensuse-leap OS_DIST="leap:" OS_VERSION=15.2 OS_INSTALL="zypper --no-gpg-checks --non-interactive install" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=no"
         - arch: amd64
-          env: OS_ARCH=x86_64 OS_TYPE="opensuse/" OS_MOCK=opensuse OS_DIST= OS_VERSION=tumbleweed OS_INSTALL="zypper --no-gpg-checks --non-interactive install" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=yes"
+          env: OS_ARCH=x86_64 OS_TYPE="opensuse/" OS_MOCK=opensuse OS_DIST= OS_VERSION=tumbleweed OS_INSTALL="zypper --no-gpg-checks --non-interactive install" DOCKER_OPTS="--privileged" TEST_ENV="SBD_USE_DM=no"
 
 services:
   - docker

--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,12 @@ AC_TEST_NO_QUORUM_POLICY(no_quorum_demote)
 dnl check for new pe-API
 AC_CHECK_FUNCS(pe_new_working_set)
 
+dnl check if votequorum comes with default for qdevice-sync_timeout
+AC_CHECK_DECLS([VOTEQUORUM_QDEVICE_DEFAULT_SYNC_TIMEOUT],
+               HAVE_DECL_VOTEQUORUM_QDEVICE_DEFAULT_SYNC_TIMEOUT=1,
+               HAVE_DECL_VOTEQUORUM_QDEVICE_DEFAULT_SYNC_TIMEOUT=0,
+               [#include <corosync/votequorum.h>])
+
 if test "$missing" = "yes"; then
    AC_MSG_ERROR([Missing required libraries or functions.])
 fi
@@ -139,6 +145,13 @@ AM_CONDITIONAL(CHECK_TWO_NODE, test "$HAVE_cmap" = "1")
 
 AC_DEFINE_UNQUOTED(CHECK_VOTEQUORUM_HANDLE, $HAVE_votequorum, Turn on periodic checking of votequorum-handle)
 AM_CONDITIONAL(CHECK_VOTEQUORUM_HANDLE, test "$HAVE_votequorum" = "1")
+
+AC_DEFINE_UNQUOTED(CHECK_QDEVICE_SYNC_TIMEOUT,
+                   ($HAVE_DECL_VOTEQUORUM_QDEVICE_DEFAULT_SYNC_TIMEOUT && $HAVE_cmap),
+                   Turn on checking if watchdog-timeout and qdevice-sync_timeout are matching)
+AM_CONDITIONAL(CHECK_QDEVICE_SYNC_TIMEOUT,
+               test "$HAVE_DECL_VOTEQUORUM_QDEVICE_DEFAULT_SYNC_TIMEOUT" = "1" &&
+               test "$HAVE_cmap" = "1")
 
 CONFIGDIR=""
 AC_ARG_WITH(configdir,


### PR DESCRIPTION
If qdevice is used and sync_timeout is higher than watchdog-timeout then
we can't be sure that quorum-state is updated quick enough so that
it can be used to trigger a suicide reliably quick.
Thus it is advisable to prevent startup of resources in such a case
(as we are doing when pacemaker finds stonith-watchdog-timeout
too small for the watchdog-timeout set in sbd). This can easily
be achieved by delaying sbd-startup (finally systemd will make
an end to it after the startup-timeout configured with the unit)
till the timing-requirements are fulfilled. While in the sbd-startup-delay
phase the admin can still correct qdevice timing.
When qdevice is enabled during operation or timing is modified
this is checked via cmap-tracking of quorum.device.mode &
quorum.device.sync_timeout.
Of course when resources are running already we've run out of
elegant options to cope with the situation - prio 1 prevent
split brain. Only thing we can do here is behave as if we just
lost quorum. Which usually means suicide.

Implementation wise the things to be done are amazingly similar
to what is done when checking 2-node-setup:
Get/track some info from cmap + check consistency with
other config -> if inconsistent distrust quorum-info from
pacemaker
