### PR TITLE
[build] ship sbd.pc with basic sbd build information for downstream p…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ sbd.sysconfig
 sbd-*/
 .deps
 test-driver
+sbd.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,9 @@ export SBD_USE_DM := no
 
 EXTRA_DIST      = sbd.spec tests/regressions.sh man/sbd.8.pod.in
 
+pkgconfigdir	= $(datadir)/pkgconfig
+pkgconfig_DATA	= sbd.pc
+
 export:
 	rm -f $(PACKAGE)-HEAD.tar.*
 	if test "$(KEEP_EXISTING_TAR)" != "yes"; then \

--- a/configure.ac
+++ b/configure.ac
@@ -345,7 +345,7 @@ fi
 AC_SUBST(SBD_SYNC_RESOURCE_STARTUP_SYSCONFIG)
 
 dnl The Makefiles and shell scripts we output
-AC_CONFIG_FILES([Makefile src/Makefile agent/Makefile man/Makefile agent/sbd src/sbd.service src/sbd_remote.service src/sbd.sh src/sbd.sysconfig])
+AC_CONFIG_FILES([Makefile src/Makefile agent/Makefile man/Makefile agent/sbd src/sbd.service src/sbd_remote.service src/sbd.sh src/sbd.sysconfig sbd.pc])
 
 AC_CONFIG_SUBDIRS([tests])
 

--- a/sbd.pc.in
+++ b/sbd.pc.in
@@ -1,0 +1,7 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+confdir=@CONFIGDIR@
+
+Name: @PACKAGE@
+Version: @VERSION@
+Description: @PACKAGE@ build information required for downstream projects

--- a/sbd.spec
+++ b/sbd.spec
@@ -137,6 +137,7 @@ rm -rf %{buildroot}
 %config(noreplace) %{_sysconfdir}/sysconfig/sbd
 %{_sbindir}/sbd
 %{_datadir}/sbd
+%{_datadir}/pkgconfig/sbd.pc
 %exclude %{_datadir}/sbd/regressions.sh
 %doc %{_mandir}/man8/sbd*
 %if %{defined _unitdir}


### PR DESCRIPTION
In a similar fashion to:
https://github.com/ClusterLabs/booth/pull/104
https://github.com/ClusterLabs/fence-agents/pull/365
https://github.com/ClusterLabs/resource-agents/pull/1576
https://github.com/corosync/corosync-qdevice/pull/15

ship a .pc file that can be used by CI and other downstream projects to determine sbd build configuration.

pacemaker change are also on the way.