### PR TITLE
Fix: sbd-inquisitor: check SBD_SYNC_RESOURCE_STARTUP only in watch mode

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -972,25 +972,6 @@ int main(int argc, char **argv, char **envp)
             }
         }
 
-        value = getenv("SBD_SYNC_RESOURCE_STARTUP");
-        sync_resource_startup =
-            crm_is_true(value?value:SBD_SYNC_RESOURCE_STARTUP_DEFAULT);
-
-#if !USE_PACEMAKERD_API
-        if (sync_resource_startup) {
-            fprintf(stderr, "Failed to sync resource-startup as "
-                "SBD was built against pacemaker not supporting pacemakerd-API.\n");
-            exit_status = -1;
-            goto out;
-        }
-#else
-        if (!sync_resource_startup) {
-            cl_log(LOG_WARNING, "SBD built against pacemaker supporting "
-                             "pacemakerd-API. Should think about enabling "
-                             "SBD_SYNC_RESOURCE_STARTUP.");
-        }
-#endif
-
 	while ((c = getopt(argc, argv, "czC:DPRTWZhvw:d:n:p:1:2:3:4:5:t:I:F:S:s:r:")) != -1) {
 		switch (c) {
 		case 'D':
@@ -1126,6 +1107,27 @@ int main(int argc, char **argv, char **envp)
 			break;
 		}
 	}
+
+    if (strcmp(argv[optind], "watch") == 0) {
+        value = getenv("SBD_SYNC_RESOURCE_STARTUP");
+        sync_resource_startup =
+            crm_is_true(value?value:SBD_SYNC_RESOURCE_STARTUP_DEFAULT);
+
+#if !USE_PACEMAKERD_API
+        if (sync_resource_startup) {
+            fprintf(stderr, "Failed to sync resource-startup as "
+                "SBD was built against pacemaker not supporting pacemakerd-API.\n");
+            exit_status = -1;
+            goto out;
+        }
+#else
+        if (!sync_resource_startup) {
+            cl_log(LOG_WARNING, "SBD built against pacemaker supporting "
+                             "pacemakerd-API. Should think about enabling "
+                             "SBD_SYNC_RESOURCE_STARTUP.");
+        }
+#endif
+    }
 
     if (disk_count == 0) {
         /* if we already have disks from commandline


### PR DESCRIPTION
Due to the change of https://github.com/ClusterLabs/sbd/commit/f4d38a073ce3bfa2078792f1cc85229457430292, a warning is output to syslog when the sbd command is executed, which confuses users.
```
# cat /etc/redhat-release
Red Hat Enterprise Linux release 8.3 (Ootpa)

# rpm -q sbd
sbd-1.4.1-7.el8.x86_64

# grep SBD_SYNC_RESOURCE_STARTUP /etc/sysconfig/sbd
SBD_SYNC_RESOURCE_STARTUP=yes

(1)
# sbd query-watchdog

Discovered 2 watchdog devices:

[1] /dev/watchdog
Identity: i6300ESB timer
Driver: <unknown>

[2] /dev/watchdog0
Identity: i6300ESB timer
Driver: <unknown>

# grep daemon.warning /var/log/messages
Dec 11 12:02:25 rhel83-1 <daemon.warning> sbd[1846233]: warning: main: SBD built against pacemaker supporting pacemakerd-API. Should think about enabling SBD_SYNC_RESOURCE_STARTUP.

(2)
# sosreport --batch --tmp-dir=/tmp -k sar.all_sar=on

sosreport (version 3.9)
  :
  Starting 76/119 pacemaker       [Running: insights networking networkmanager pacemaker]  *1
  :

# grep daemon.warning /var/log/messages
Dec 11 12:21:04 rhel83-2 <daemon.warning> sbd[1851079]: warning: main: SBD built against pacemaker supporting pacemakerd-API. Should think about enabling SBD_SYNC_RESOURCE_STARTUP.

 *1 'pcs stonith sbd watchdog list', i.e. '/usr/sbin/sbd query-watchdog', will be executed
```
Isn't this check only required for "watch" mode?