### PR TITLE
Fix 100% CPU usage when CMAP connection is lost

### DIFF
--- a/src/sbd-cluster.c
+++ b/src/sbd-cluster.c
@@ -35,6 +35,18 @@
 
 #if CHECK_TWO_NODE || CHECK_QDEVICE_SYNC_TIMEOUT
 #include <glib-unix.h>
+// available since glib 2.58
+#ifndef G_SOURCE_FUNC
+#define G_SOURCE_FUNC(f) ((GSourceFunc) (void (*)(void)) (f))
+#endif
+// available since glib 2.32
+#ifndef G_SOURCE_REMOVE
+#define G_SOURCE_REMOVE FALSE
+#endif
+// available since glib 2.32
+#ifndef G_SOURCE_CONTINUE
+#define G_SOURCE_CONTINUE TRUE
+#endif
 #endif
 
 #include "sbd.h"
@@ -55,6 +67,7 @@ static int reconnect_msec = 1000;
 static GMainLoop *mainloop = NULL;
 static guint notify_timer = 0;
 static crm_cluster_t cluster;
+static void clean_up(int rc);
 static gboolean sbd_remote_check(gpointer user_data);
 static long unsigned int find_pacemaker_remote(void);
 static void sbd_membership_destroy(gpointer user_data);
@@ -292,10 +305,19 @@ static void sbd_cmap_notify_fn(
 }
 
 static gboolean
-cmap_dispatch_callback (gpointer user_data)
+cmap_dispatch_callback (gint cmap_fd,
+                        GIOCondition condition,
+                        gpointer user_data)
 {
+    /* CMAP connection lost */
+    if (condition & G_IO_HUP) {
+        cl_log(LOG_WARNING, "CMAP service connection lost\n");
+        clean_up(EXIT_CLUSTER_DISCONNECT);
+        /* remove the source from the main loop */
+        return G_SOURCE_REMOVE; /* never reached */
+    }
     cmap_dispatch(cmap_handle, CS_DISPATCH_ALL);
-    return TRUE;
+    return G_SOURCE_CONTINUE;
 }
 
 static void
@@ -370,7 +392,7 @@ verify_against_cmap_config(void)
             cl_log(LOG_WARNING, "Couldn't create source for cmap\n");
             goto out;
         }
-        g_source_set_callback(cmap_source, cmap_dispatch_callback, NULL, NULL);
+        g_source_set_callback(cmap_source, G_SOURCE_FUNC(cmap_dispatch_callback), NULL, NULL);
         g_source_attach(cmap_source, NULL);
     }
 
@@ -733,6 +755,15 @@ clean_up(int rc)
                             * just to be back where we started
                             */
 #endif
+
+#if SUPPORT_COROSYNC && CHECK_TWO_NODE
+    cmap_destroy();
+#endif
+
+    if (rc >= 0) {
+        exit(rc);
+    }
+
     return;
 }
 

--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -554,6 +554,20 @@ void inquisitor_child(void)
 									break;
 							}
 						}
+					} else if (sbd_is_cluster(s)) {
+						if (WIFEXITED(status)) {
+							switch(WEXITSTATUS(status)) {
+								case EXIT_CLUSTER_DISCONNECT:
+									cl_log(LOG_WARNING, "Cluster-Servant has exited (connection lost)");
+									s->restarts = 0;
+									s->restart_blocked = 0;
+									s->outdated = 1;
+									s->t_last.tv_sec = 0;
+									break;
+								default:
+									break;
+							}
+						}
 					}
 					cleanup_servant_by_pid(pid);
 				}

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -62,6 +62,9 @@
 /* exit status for pcmk-servant */
 #define EXIT_PCMK_SERVANT_GRACEFUL_SHUTDOWN 30
 
+/* exit status for cluster-servant */
+#define EXIT_CLUSTER_DISCONNECT 40
+
 #define HOG_CHAR	0xff
 #define SECTOR_NAME_MAX 63
 


### PR DESCRIPTION
When CMAP disconnects sbd results in 100% CPU usage.

This patch is currently used on SUSE, so upstreaming seem reasonable.