### PR TITLE
Fix: sbd-inquisitor: tolerate and strip any leading spaces of command line option values

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -999,6 +999,15 @@ int main(int argc, char **argv, char **envp)
         }
 
 	while ((c = getopt(argc, argv, "czC:DPRTWZhvw:d:n:p:1:2:3:4:5:t:I:F:S:s:r:")) != -1) {
+		/* Call it before checking optarg for NULL to make coverity happy */
+		const char *sanitized_optarg = sanitize_option_value(optarg);
+
+		if (optarg && sanitized_optarg == NULL) {
+			fprintf(stderr, "Invalid value \"%s\" for option -%c\n", optarg, c);
+			exit_status = -2;
+			goto out;
+		}
+
 		switch (c) {
 		case 'D':
 			break;
@@ -1011,11 +1020,11 @@ int main(int argc, char **argv, char **envp)
 			cl_log(LOG_INFO, "Realtime mode deactivated.");
 			break;
 		case 'S':
-			start_mode = atoi(optarg);
+			start_mode = atoi(sanitized_optarg);
 			cl_log(LOG_INFO, "Start mode set to: %d", (int)start_mode);
 			break;
 		case 's':
-			timeout_startup = atoi(optarg);
+			timeout_startup = atoi(sanitized_optarg);
 			cl_log(LOG_INFO, "Start timeout set to: %d", (int)timeout_startup);
 			break;
 		case 'v':
@@ -1043,13 +1052,13 @@ int main(int argc, char **argv, char **envp)
 			break;
 		case 'w':
                         free(watchdogdev);
-                        watchdogdev = strdup(optarg);
+                        watchdogdev = strdup(sanitized_optarg);
                         watchdogdev_is_default = false;
                         cl_log(LOG_NOTICE, "Using watchdog device '%s'", watchdogdev);
 			break;
 		case 'd':
 #if SUPPORT_SHARED_DISK
-			if (recruit_servant(optarg, 0) != 0) {
+			if (recruit_servant(sanitized_optarg, 0) != 0) {
 				fprintf(stderr, "Invalid device: %s\n", optarg);
 				exit_status = -1;
 				goto out;
@@ -1070,48 +1079,48 @@ int main(int argc, char **argv, char **envp)
 			disk_priority = 0;
 			break;
 		case 'n':
-			local_uname = strdup(optarg);
+			local_uname = strdup(sanitized_optarg);
 			cl_log(LOG_INFO, "Overriding local hostname to %s", local_uname);
 			break;
 		case 'p':
-			pidfile = strdup(optarg);
+			pidfile = strdup(sanitized_optarg);
 			cl_log(LOG_INFO, "pidfile set to %s", pidfile);
 			break;
 		case 'C':
-			timeout_watchdog_crashdump = atoi(optarg);
+			timeout_watchdog_crashdump = atoi(sanitized_optarg);
 			cl_log(LOG_INFO, "Setting crashdump watchdog timeout to %d",
 					(int)timeout_watchdog_crashdump);
 			break;
 		case '1':
-			timeout_watchdog = atoi(optarg);
+			timeout_watchdog = atoi(sanitized_optarg);
 			break;
 		case '2':
-			timeout_allocate = atoi(optarg);
+			timeout_allocate = atoi(sanitized_optarg);
 			break;
 		case '3':
-			timeout_loop = atoi(optarg);
+			timeout_loop = atoi(sanitized_optarg);
 			break;
 		case '4':
-			timeout_msgwait = atoi(optarg);
+			timeout_msgwait = atoi(sanitized_optarg);
 			break;
 		case '5':
-			timeout_watchdog_warn = atoi(optarg);
+			timeout_watchdog_warn = atoi(sanitized_optarg);
 			do_calculate_timeout_watchdog_warn = false;
 			cl_log(LOG_INFO, "Setting latency warning to %d",
 					(int)timeout_watchdog_warn);
 			break;
 		case 't':
-			servant_restart_interval = atoi(optarg);
+			servant_restart_interval = atoi(sanitized_optarg);
 			cl_log(LOG_INFO, "Setting servant restart interval to %d",
 					(int)servant_restart_interval);
 			break;
 		case 'I':
-			timeout_io = atoi(optarg);
+			timeout_io = atoi(sanitized_optarg);
 			cl_log(LOG_INFO, "Setting IO timeout to %d",
 					(int)timeout_io);
 			break;
 		case 'F':
-			servant_restart_count = atoi(optarg);
+			servant_restart_count = atoi(sanitized_optarg);
 			cl_log(LOG_INFO, "Servant restart count set to %d",
 					(int)servant_restart_count);
 			break;
@@ -1119,7 +1128,7 @@ int main(int argc, char **argv, char **envp)
 			if (timeout_action) {
 				free(timeout_action);
 			}
-			timeout_action = strdup(optarg);
+			timeout_action = strdup(sanitized_optarg);
 			break;
 		case 'h':
 			usage();

--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -1042,10 +1042,10 @@ int main(int argc, char **argv, char **envp)
 			W_count++;
 			break;
 		case 'w':
-                        cl_log(LOG_NOTICE, "Using watchdog device '%s'", watchdogdev);
                         free(watchdogdev);
                         watchdogdev = strdup(optarg);
                         watchdogdev_is_default = false;
+                        cl_log(LOG_NOTICE, "Using watchdog device '%s'", watchdogdev);
 			break;
 		case 'd':
 #if SUPPORT_SHARED_DISK

--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -40,9 +40,8 @@ bool sync_resource_startup = false;
 int parse_device_line(const char *line);
 
 static const char *
-get_env_option(const char *option)
+sanitize_option_value(const char *value)
 {
-	const char *value = getenv(option);
 	size_t max = 0;
 	size_t lpc = 0;
 
@@ -59,6 +58,14 @@ get_env_option(const char *option)
 	}
 
 	return (strlen(value + lpc) > 0 ? (value + lpc) : NULL);
+}
+
+static const char *
+get_env_option(const char *option)
+{
+	const char *value = getenv(option);
+
+	return sanitize_option_value(value);
 }
 
 static int


### PR DESCRIPTION
Somehow an user's own monitoring agent doesn't well parse an SBD_DEVICE
setting with spaces between the device names:

`SBD_DEVICE="/dev/<a>; /dev/<b>; /dev/<c>"`

And eventually it calls an sbd command:

`sbd list -d " /dev/<b>"`

--  A space is prefixed to the device name which is quoted.

Of course it could be easily fixed in the setting or their agent. But
OTOH, sbd'd better tolerate and strip any leading spaces of command line
option values.