### PR TITLE
[WIP] Fix: avoid using deprecated valloc & frequent aligned alloc

### DIFF
--- a/src/sbd-md.c
+++ b/src/sbd-md.c
@@ -92,6 +92,9 @@ close_device(struct sbd_context *st)
 	if (!st) {
 		return;
 	}
+	if (st->ioctx) {
+		io_destroy(st->ioctx);
+	}
 	if (st->devfd >= 0) {
 		close(st->devfd);
 	}

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -108,6 +108,7 @@ struct sbd_context {
 	int	devfd;
 	io_context_t	ioctx;
 	struct iocb	io;
+	void *buffer;
 };
 
 enum pcmk_health 


### PR DESCRIPTION
switch to using a single aligned buffer that stays allocated.

- free to use allocation mechanism that doesn't allow to
  use free() to hand back (not needed for current posix_memalign)

- avoid memory fragmentation risk (and thus risk to run out of
  hogged memory) due to frequent alloc/free of aligned memory

Switching from ```forking``` to ```simple``` should probably be
thought over again as sbd is doing quite some checks that
should be done before systemd should assume sbd as started
and thus start pacemaker.
Nothing severe should happen though since we have startup-
synchronization between the daemons meanwhile.
To leave legacy ```forking``` startup behind and still have the
behavior that pacemaker is just started by systemd when sbd
has checked config, watchdog-device & disks ```notify``` is
probably the only way.
More important is that pacemaker is atm using the sbd-pid-file to
detect a running sbd-daemon and thus assume it should
synchronize with it. More robust would probably be to ask
systemd (if compiled with systemd-support) if sbd is enabled
and it would work without a pid-file.