### PR TITLE
test: a few tweaks regarding setup of test-environment

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,8 @@ COMMIT_COUNTER	?= $(shell git describe --tags --long --always --match v$(SPEC_VE
 TESTS           = tests/regressions.sh
 export SBD_BINARY := src/sbd
 export SBD_PRELOAD := tests/.libs/libsbdtestbed.so
-export SBD_USE_DM := no
+export SBD_USE_DM ?= no
+export SBD_TRANSLATE_AIO ?= no
 
 EXTRA_DIST      = sbd.spec tests/regressions.sh man/sbd.8.pod.in
 


### PR DESCRIPTION
- have image-files in /dev/shm to assure they are in memory and
  sbd opening the files with O_SYNC doesn't trigger unnecessary
  syncs on a heavily loaded test-machine
- wrapping away libaio and usage of device-mapper for block-device
  simulation can now be passed into make via
  SBD_USE_DM & SBD_TRANSLATE_AIO
- have variables that configure test-environment be printed
  out prior to running tests