### PR TITLE
Fix: sbd-inquisitor: SBD_SYNC_RESOURCE_STARTUP should consider SBD_PACEMAKER

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -1281,13 +1281,6 @@ int main(int argc, char **argv, char **envp)
                              "pacemakerd-API. Should think about enabling "
                              "SBD_SYNC_RESOURCE_STARTUP.");
         }
-
-        if (sync_resource_startup && !check_pcmk) {
-            fprintf(stderr, "Failed to sync resource-startup as "
-                "pacemaker checks are off.\n");
-            exit_status = -1;
-            goto out;
-        }
 #endif
     }
 


### PR DESCRIPTION
Currently, if `SBD_SYNC_RESOURCE_STARTUP=false` and
`SBD_PACEMAKER=false`, sbd prints a warning every time it runs: "Should
think about enabling SBD_SYNC_RESOURCE_STARTUP." But this warning can
never be addressed, since `SBD_SYNC_RESOURCE_STARTUP=true` doesn't work
with `SBD_PACEMAKER=false`.

Additionally, if `SBD_PACEMAKER=false` but
`SBD_SYNC_RESOURCE_STARTUP=true`, the `SBD_SYNC_RESOURCE_STARTUP=true`
will have no effect, since `SBD_PACEMAKER` controls whether sbd sends
the ping to pacemaker. (If pacemaker is also configured with
`SBD_SYNC_RESOURCE_STARTUP=true`, it will hang forever waiting for the
ping from sbd that never comes.)

Handle both of these cases by checking the values of
`SBD_SYNC_RESOURCE_STARTUP` and `SBD_PACEMAKER`:

* `SBD_SYNC_RESOURCE_STARTUP=true`, `SBD_PACEMAKER=true`: No change.
Startup syncs as expected.

* `SBD_SYNC_RESOURCE_STARTUP=false`, `SBD_PACEMAKER=true`: No change.
Sbd warns about enabling `SBD_SYNC_RESOURCE_STARTUP` as expected.

* `SBD_SYNC_RESOURCE_STARTUP=true`, `SBD_PACEMAKER=false`: Currently,
pacemaker would hang. With the fix, sbd aborts with an error.

* `SBD_SYNC_RESOURCE_STARTUP=false`, `SBD_PACEMAKER=false`: Currently,
sbd warns about enabling `SBD_SYNC_RESOURCE_STARTUP`. With the fix, the
behavior is the same as it was before `SBD_SYNC_RESOURCE_STARTUP` was
introduced: no warning.