### PR TITLE
Refactor strange dynamic-allocation-finding of gcc-12

### DIFF
--- a/src/sbd-md.c
+++ b/src/sbd-md.c
@@ -593,9 +593,9 @@ slot_list(struct sbd_context *st)
 		}
 	}
 
-out:	free(s_node);
+out:	free(s_mbox);
+	free(s_node);
 	free(s_header);
-	free(s_mbox);
 	return rc;
 }
 


### PR DESCRIPTION
in slot_list instead of jumping to the common out-code.
Using the common out-code should just add 3x free(NULL)
but gcc-12 dynamic-memory static analysis does complain.
The code doesn't get that more ugly so let's do gcc the
favor for now.

This is the patch for doing the early return:
```
@@ -573,7 +573,7 @@ slot_list(struct sbd_context *st)

	s_header = header_get(st);
	if (!s_header) {
		rc = -1; goto out;
		return -1;
	}

	s_node = sector_alloc();
```

Strange is that changing the order of the cleanup-code
seems to satisfy gcc as well.
Doing the de-allocation in reverse order compared to 
allocation might be a bit cleaner but shouldn't have any
influence here.
So let's rather go with that.