### PR TITLE
rpm: use new package name for pacemaker devel on opensuse

### DIFF
--- a/sbd.spec
+++ b/sbd.spec
@@ -63,7 +63,7 @@ BuildRequires:  glib2-devel
 BuildRequires:  libaio-devel
 BuildRequires:  corosync-devel
 %if 0%{?suse_version}
-BuildRequires:  libpacemaker-devel
+BuildRequires:  libpacemaker3-devel
 %else
 BuildRequires:  pacemaker-libs-devel
 %endif


### PR DESCRIPTION
Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>