### PR TITLE
rpm: use new package name for pacemaker devel on opensuse (take 2)

### DIFF
--- a/sbd.spec
+++ b/sbd.spec
@@ -63,7 +63,11 @@ BuildRequires:  glib2-devel
 BuildRequires:  libaio-devel
 BuildRequires:  corosync-devel
 %if 0%{?suse_version}
+%if 0%{?suse_version} > 1500
 BuildRequires:  libpacemaker3-devel
+%else
+BuildRequires:  libpacemaker-devel
+%endif
 %else
 BuildRequires:  pacemaker-libs-devel
 %endif


### PR DESCRIPTION
opensuse 15 still uses the old package name, while tumbleweed the new
one

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>