### PR TITLE
[don't merge] just a heads-up

### DIFF
--- a/Moving_to_pipelines.txt
+++ b/Moving_to_pipelines.txt
@@ -1,0 +1,2 @@
+Fabbione is gonna be moving CI to the pipelines-plugin during 2023-06-15.
+it will generate some spam on the PRs and old PRs will need to be rebased on top of the latest


### PR DESCRIPTION
Fabbione is gonna be moving CI for the SBD-repo to the pipelines-plugin during 2023-06-15.
It will generate some spam on the PRs and old PRs will need to be rebased on top of the latest.

This is just a heads-up for you to know why what you will see is happening ;-)
                                                                                      