### PR TITLE
test: load libaio.so instead of libaio.so.1

### DIFF
--- a/tests/sbd-testbed.c
+++ b/tests/sbd-testbed.c
@@ -154,7 +154,7 @@ init (void)
         orig_fopen        = (orig_fopen_f_type)dlsym_fatal(RTLD_NEXT,"fopen");
         orig_fclose       = (orig_fclose_f_type)dlsym_fatal(RTLD_NEXT,"fclose");
 
-        handle = dlopen("libaio.so.1",  RTLD_NOW);
+        handle = dlopen("libaio.so",  RTLD_NOW);
         if (!handle) {
             fprintf(stderr, "Failed opening libaio.so.1\n");
             exit(1);


### PR DESCRIPTION
as that is rather what sbd would link against without preloading on distros linking different library versions under these 2 names