### PR TITLE
Fix: sbd-inquisitor: avoid parsing SBD_DELAY_START as a time duration if its value is boolean false

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -988,9 +988,7 @@ int main(int argc, char **argv, char **envp)
 
         value = get_env_option("SBD_DELAY_START");
         if(value) {
-            delay_start = crm_is_true(value);
-
-            if (!delay_start) {
+            if (crm_str_to_boolean(value, (int *) &delay_start) != 1) {
                 delay = crm_get_msec(value) / 1000;
                 if (delay > 0) {
                     delay_start = true;


### PR DESCRIPTION
... to prevent the unnecessary call to crm_get_msec() and the warning about an invalid value.

This addresses the issue brought up from:
https://github.com/ClusterLabs/pacemaker/pull/3643#pullrequestreview-2448716154