### PR TITLE
cleanup header import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+CLAUDE.md
 *.m4
 *.cache
 compile

--- a/src/sbd-cluster.c
+++ b/src/sbd-cluster.c
@@ -30,6 +30,7 @@
 #include <config.h>
 #include <crm_config.h>
 
+#include <crm/crm.h>
 #include <crm/cluster.h>
 #include <crm/common/mainloop.h>
 


### PR DESCRIPTION
cleanup header import including <crm/crm.h> directly in sbd-cluster.c.
And ignore CLAUDE.md - as otherwise build is failing when it sees an untracked file.