### PR TITLE
Coverity issues

### DIFF
--- a/src/sbd-common.c
+++ b/src/sbd-common.c
@@ -252,6 +252,7 @@ static int get_realtime_budget(void)
                          &namespecs, &cgroup)) !=EOF ) {
         if (namespecs && strstr(namespecs, "cpuacct")) {
             free(namespecs);
+            namespecs = NULL;
             break;
         }
         if (cgroup) {
@@ -292,6 +293,9 @@ static int get_realtime_budget(void)
 exit_res:
     if (cgroup) {
         free(cgroup);
+    }
+    if (namespecs) {
+        free(namespecs);
     }
     return res;
 }

--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -779,8 +779,6 @@ void inquisitor_child(void)
 			}
 		}
 	}
-	/* not reached */
-	exit(0);
 }
 
 int inquisitor(void)

--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -401,17 +401,19 @@ sbd_lock_pidfile(const char *filename)
 
 	switch (link(tf_name, lf_name)) {
 	case 0:
-		if (stat(tf_name, &sbuf) < 0) {
+		fd = open(tf_name, O_RDONLY);
+		if (fd < 0 || fstat(fd, &sbuf) < 0) {
 			/* something weird happened */
 			rc = -3;
-			break;
-		}
-		if (sbuf.st_nlink < 2) {
+		} else if (sbuf.st_nlink < 2) {
 			/* somehow, it didn't get through - NFS trouble? */
 			rc = -2;
-			break;
+		} else {
+			rc = 0;
 		}
-		rc = 0;
+		if (fd >= 0) {
+			close(fd);
+		}
 		break;
 	case EEXIST:
 		rc = -1;

--- a/src/sbd-watchdog.c
+++ b/src/sbd-watchdog.c
@@ -303,6 +303,8 @@ watchdog_populate_list(void)
                     memmove(&buf[sizeof(WATCHDOG_NODEDIR)-1], buf, len+1);
                     memcpy(buf, WATCHDOG_NODEDIR, sizeof(WATCHDOG_NODEDIR)-1);
                     len += sizeof(WATCHDOG_NODEDIR)-1;
+                    /* redundant due to memmove above - make coverity happy */
+                    buf[len] = '\0';
                 }
                 if (strstr(buf, "/../") ||
                     strncmp(WATCHDOG_NODEDIR, buf,


### PR DESCRIPTION
everything but freeing the namespec is definitely coverity false positives but ...
and even that is highly unlikely to happen if kernel output changes and it is anyway just called once during life-time so ...

